### PR TITLE
[add] give possibility to configure default ursadb index types

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -4,3 +4,4 @@ REDIS_PORT = 6379
 SECRET_KEY = 'secret-key'
 REPO_URL = 'https://database/analysis?hash={hash}'
 INDEXABLE_PATHS = ['/mnt/samples']
+INDEX_TYPE = '[gram3, text4, hash4, wide8]'

--- a/daemon.py
+++ b/daemon.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 import yara
-from plyara import interp
+import plyara
 from yara import SyntaxError
 
 import config
@@ -51,7 +51,7 @@ def execute_job(job_id, hash, yara_rule):
     })
 
     try:
-        rules = interp.parseString(yara_rule)
+        rules = plyara.Plyara().parse_string(yara_rule)
         parser = YaraParser(rules[0])
         parsed = parser.parse()
     except Exception as e:

--- a/lib/ursadb.py
+++ b/lib/ursadb.py
@@ -1,7 +1,13 @@
 import time
 import json
-
 import zmq
+import os,sys,inspect
+
+current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parent_dir = os.path.dirname(current_dir)
+sys.path.insert(0, parent_dir)
+
+from config import INDEX_TYPE
 
 
 class UrsaDb(object):
@@ -43,7 +49,7 @@ class UrsaDb(object):
 
     def index(self, path):
         socket = self.make_socket(recv_timeout=-1)
-        socket.send('index "{}" with [gram3, text4, hash4, wide8];'.format(path))
+        socket.send('index "{path}" with {index_type};'.format(path=path,index_type=INDEX_TYPE))
         response = socket.recv_string()
         socket.close()
 

--- a/webapp.py
+++ b/webapp.py
@@ -9,7 +9,7 @@ from zmq import Again
 
 from lib.ursadb import UrsaDb
 from lib.yaraparse import YaraParser
-import plyara.interp as interp
+import plyara
 
 from util import make_redis, make_serializer
 import config
@@ -176,7 +176,7 @@ def query_by_hash(qhash):
     yara = redis.get('query:' + qhash)
 
     try:
-        rules = interp.parseString(yara)
+        rules = plyara.Plyara().parse_string(yara)
     except Exception as e:
         return error_page(yara, 'PLYara failed (not my fault): ' + str(e))
 


### PR DESCRIPTION
- added `INDEX_TYPE` field in `config.example.py` 

- updated `lib/ursadb.py` accordingly to changes in `config.example.py` 

So that, added paths via the `mquery admin` page, can be indexed with custom index types as set in the config