### PR TITLE
Allow users to specify multiple rules

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -10,9 +10,9 @@ from yara import SyntaxError
 
 import config
 from lib.ursadb import UrsaDb
-from lib.yaraparse import parse_string
+from lib.yaraparse import parse_yara, combine_rules
 from util import make_redis, setup_logging
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 redis = make_redis()
 db = UrsaDb(config.BACKEND)
@@ -97,8 +97,13 @@ def job_daemon() -> None:
                 )
 
         elif queue == "queue-metadata":
+            # LEGACY QUEUE
+            # Exists mostly because there is no sane way to do migrations
+            # for job queues in redis.
+            # This is currently a "drain only" queue that will pick up any
+            # pending tasks during mquery update, and will stay idle forever.
             job_hash, file_path = data.split(":", 1)
-            execute_metadata(job_hash, file_path)
+            update_metadata(job_hash, file_path, [])
 
         elif queue == "queue-commands":
             logging.info("Running a command: %s", data)
@@ -109,7 +114,7 @@ def job_daemon() -> None:
             collect_expired_jobs()
 
 
-def execute_metadata(job_hash: str, file_path: str) -> None:
+def update_metadata(job_hash: str, file_path: str, matches: List[str]) -> None:
     if redis.hget("job:" + job_hash, "status") in [
         "cancelled",
         "failed",
@@ -147,7 +152,7 @@ def execute_metadata(job_hash: str, file_path: str) -> None:
     pipe = redis.pipeline()
     pipe.rpush(
         "meta:{}".format(job_hash),
-        json.dumps({"file": file_path, "meta": flat_meta}),
+        json.dumps({"file": file_path, "meta": flat_meta, "matches": matches}),
     )
     pipe.hget("job:{}".format(job_hash), "total_files")
     pipe.hincrby("job:{}".format(job_hash), "files_processed")
@@ -179,7 +184,7 @@ def execute_yara(job_hash: str, file: str) -> None:
 
     if matches:
         logging.info("Processed (match): {}".format(file))
-        redis.rpush("queue-metadata", "{}:{}".format(job_hash, file))
+        update_metadata(job_hash, file, [r.rule for r in matches])
     else:
         logging.info("Processed (nope ): {}".format(file))
 
@@ -203,29 +208,22 @@ def execute_search(job_hash: str) -> None:
         "job:" + job_hash, {"status": "parsing", "timestamp": time.time()}
     )
 
-    try:
-        parsed = parse_string(yara_rule)
-    except Exception as e:
-        logging.exception(e)
-        raise RuntimeError("Failed to parse Yara")
+    rules = parse_yara(yara_rule)
+    parsed = combine_rules(rules)
 
     redis.hmset(
         "job:" + job_hash, {"status": "querying", "timestamp": time.time()}
     )
 
-    taint = job.get("taint", None)
-
     logging.info("Querying backend...")
-    result = db.query(parsed, taint)
+    taint = job.get("taint", None)
+    result = db.query(parsed.query, taint)
     if "error" in result:
         raise RuntimeError(result["error"])
 
     files = [f for f in result["files"] if f.strip()]
 
     logging.info("Database responded with {} files".format(len(files)))
-
-    if "max_files" in job and int(job["max_files"]) > 0:
-        files = files[: int(job["max_files"])]
 
     redis.hmset(
         "job:" + job_hash,

--- a/src/lib/ursadb.py
+++ b/src/lib/ursadb.py
@@ -11,7 +11,7 @@ class UrsaDb(object):
     def __init__(self, backend: str) -> None:
         self.backend = backend
 
-    def make_socket(self, recv_timeout: int=2000) -> zmq.Context:
+    def make_socket(self, recv_timeout: int = 2000) -> zmq.Context:
         context = zmq.Context()
         socket = context.socket(zmq.REQ)
         socket.setsockopt(zmq.LINGER, 0)

--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -212,7 +212,6 @@ class RuleParseEngine:
 
     def of_expr(self, condition: OfExpression) -> Optional[UrsaExpression]:
         how_many = condition.text[: condition.text.find("of")].strip()
-        counter = None
 
         children = condition.iterated_set
 
@@ -224,15 +223,18 @@ class RuleParseEngine:
             raise YaraParseError(f"Unsupported of_expr type: {type(children)}")
 
         parsed_elements = [e for e in all_elements if e is not None]
+        unknown_count = len(all_elements) - len(parsed_elements)
 
         if how_many == "all":
-            counter = len(all_elements)
+            raw_counter = len(all_elements)
         elif how_many == "any":
-            counter = 1
+            raw_counter = 1
         else:
-            counter = int(how_many)
+            raw_counter = int(how_many)
 
-        if parsed_elements:
+        counter = raw_counter - unknown_count
+
+        if counter > 0:
             return UrsaExpression.min_of(counter, *parsed_elements)
         else:
             return None

--- a/src/mqueryfront/src/DatabaseTopology.js
+++ b/src/mqueryfront/src/DatabaseTopology.js
@@ -12,7 +12,10 @@ class DatasetRow extends Component {
                 <td>
                     <code>{this.props.id}</code>
                     {this.props.taints.map((taint) => (
-                        <span class="badge badge-secondary">{taint}</span>
+                        <span>
+                            {" "}
+                            <span class="badge badge-secondary">{taint}</span>
+                        </span>
                     ))}
                 </td>
                 <td>

--- a/src/mqueryfront/src/QueryField.js
+++ b/src/mqueryfront/src/QueryField.js
@@ -165,7 +165,7 @@ class QueryField extends Component {
                             name="parse"
                             type="submit"
                             onClick={(event) =>
-                                this.handleQuery(event, "parse", "parse")
+                                this.handleQuery(event, "parse", null)
                             }
                         >
                             <span className="fa fa-code" /> Parse

--- a/src/mqueryfront/src/QueryField.js
+++ b/src/mqueryfront/src/QueryField.js
@@ -41,9 +41,10 @@ class QueryField extends Component {
     handleQuery(event, method, priority) {
         axios
             .create()
-            .post(API_URL + "/query/" + priority, {
+            .post(API_URL + "/query", {
                 raw_yara: this.state.rawYara,
                 method: method,
+                priority: priority,
                 taint: this.state.selectedTaint,
             })
             .then((response) => {
@@ -101,27 +102,27 @@ class QueryField extends Component {
 
         return (
             <div>
-                <div class="btn-group mb-1" role="group">
+                <div className="btn-group mb-1" role="group">
                     <button
                         type="button"
-                        class="btn btn-success btn-lg"
+                        className="btn btn-success btn-lg"
                         onClick={(event) =>
                             this.handleQuery(event, "query", "medium")
                         }
                     >
                         Query
                     </button>
-                    <div class="btn-group" role="group">
+                    <div className="btn-group" role="group">
                         <button
                             type="button"
-                            class="btn btn-success dropdown-toggle"
+                            className="btn btn-success dropdown-toggle"
                             data-toggle="dropdown"
                             aria-haspopup="true"
                             aria-expanded="false"
                         />
-                        <div class="dropdown-menu">
+                        <div className="dropdown-menu">
                             <a
-                                class="dropdown-item"
+                                className="dropdown-item"
                                 href="#"
                                 onClick={(event) =>
                                     this.handleQuery(event, "query", "low")
@@ -130,7 +131,7 @@ class QueryField extends Component {
                                 Low Priority Query
                             </a>
                             <a
-                                class="dropdown-item"
+                                className="dropdown-item"
                                 href="#"
                                 onClick={(event) =>
                                     this.handleQuery(event, "query", "medium")
@@ -139,7 +140,7 @@ class QueryField extends Component {
                                 Standard Priority Query
                             </a>
                             <a
-                                class="dropdown-item"
+                                className="dropdown-item"
                                 href="#"
                                 onClick={(event) =>
                                     this.handleQuery(event, "query", "high")
@@ -164,7 +165,7 @@ class QueryField extends Component {
                             name="parse"
                             type="submit"
                             onClick={(event) =>
-                                this.handleQuery(event, "parse")
+                                this.handleQuery(event, "parse", "parse")
                             }
                         >
                             <span className="fa fa-code" /> Parse

--- a/src/mqueryfront/src/QueryPage.js
+++ b/src/mqueryfront/src/QueryPage.js
@@ -47,13 +47,7 @@ class QueryPage extends Component {
         return [...new Set(taintList)];
     }
 
-    componentWillReceiveProps(newProps) {
-        console.log(newProps);
-    }
-
     updateQhash(newQhash, rawYara) {
-        console.log("update qhash called", newQhash);
-
         if (typeof rawYara !== "undefined") {
             this.setState({ rawYara: rawYara });
         }

--- a/src/mqueryfront/src/QueryStatus.js
+++ b/src/mqueryfront/src/QueryStatus.js
@@ -3,12 +3,20 @@ import axios from "axios/index";
 import { API_URL } from "./config";
 
 function MatchItem(props) {
-    const metadata = Object.keys(props.meta).map((m) => (
-        <a href={props.meta[m].url}>
-            <span className="badge badge-info">
-                {props.meta[m].display_text}
+    const metadata = Object.values(props.meta).map((v) => (
+        <a href={v.url}>
+            {" "}
+            <span className="badge badge-pill badge-warning">
+                {v.display_text}
             </span>
         </a>
+    ));
+
+    const matches = Object.values(props.matches).map((v) => (
+        <span>
+            {" "}
+            <span className="badge badge-pill badge-primary">{v}</span>
+        </span>
     ));
 
     const download_url =
@@ -22,10 +30,9 @@ function MatchItem(props) {
 
     return (
         <tr>
-            <td>
-                <a href={download_url}>{props.file}</a>
-            </td>
-            <td>{metadata}</td>
+            <a href={download_url}>{props.file}</a>
+            {matches}
+            {metadata}
         </tr>
     );
 }
@@ -166,26 +173,33 @@ class QueryStatus extends Component {
 
         if (this.state.queryPlan) {
             return (
-                <div style={{ marginTop: "55px" }}>
+                <div>
                     <h4>Parse result</h4>
-                    <div className="form-group">
-                        <label>Rule name:</label>
-                        <input
-                            type=""
-                            className="form-control"
-                            value={this.state.queryPlan.rule_name}
-                            readOnly
-                        />
-                    </div>
-                    <div className="form-group">
-                        <label>Query plan</label>
-                        <textarea
-                            className="form-control"
-                            rows="6"
-                            value={this.state.queryPlan.parsed}
-                            readOnly
-                        />
-                    </div>
+                    {this.state.queryPlan.map((rule) => (
+                        <div key={rule.rule_name} style={{ marginTop: "55px" }}>
+                            <div className="form-group">
+                                <label>
+                                    <b>{rule.rule_name}</b>
+                                    {rule.is_private ? (
+                                        <span class="badge badge-info">
+                                            private
+                                        </span>
+                                    ) : null}
+                                    {rule.is_global ? (
+                                        <span class="badge badge-info">
+                                            global
+                                        </span>
+                                    ) : null}
+                                </label>
+                                <textarea
+                                    rows="4"
+                                    className="form-control"
+                                    value={rule.parsed}
+                                    readOnly
+                                />
+                            </div>
+                        </div>
+                    ))}
                 </div>
             );
         }
@@ -289,8 +303,7 @@ class QueryStatus extends Component {
                 <table className={"table table-striped table-bordered"}>
                     <thead>
                         <tr>
-                            <th>File name</th>
-                            <th>Metadata</th>
+                            <th>Matches</th>
                         </tr>
                     </thead>
                     <tbody>{matches}</tbody>

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -1,9 +1,13 @@
+"""
+End-to-end tests for the whole infrastructore
+"""
+
+
 import sys
 import json
 import logging
 import string
 import time
-
 import zmq  # type: ignore
 import pytest  # type: ignore
 import requests
@@ -11,7 +15,7 @@ import random
 import os
 
 sys.path = [".."] + sys.path
-from lib.ursadb import UrsaDb
+from lib.ursadb import UrsaDb  # noqa
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
Another oversized PR from me. Sorry :thinking:

This will allow us to support querying using multiple yara
rules at once. Additionaly, elementary support of private and
global rules was added.

Test cases:

Trivial ones:

```
 rule Kot
{
    strings:
        $a = "xxx"

    condition:
        $a
}

rule Hmm
{
    strings:
        $a = "aaa"

    condition:
        $a and Kot
}
```

Equation group rules: https://raw.githubusercontent.com/Neo23x0/signature-base/master/yara/spy_equation_fiveeyes.yar

I think this fixes #40, but may need more refining in the future.
