### PR TITLE
Add support for anonymous strings

### DIFF
--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -60,8 +60,14 @@ class YaraRuleData:
 
     def __parse_internal(self) -> UrsaExpression:
         strings = {}
+        anonymous_no = 0
+
         for string in self.rule.strings:
-            strings[string.identifier] = string
+            if string.identifier == "$":
+                strings[f"anonymous_{anonymous_no}"] = string
+                anonymous_no += 1
+            else:
+                strings[string.identifier] = string
 
         parser = RuleParseEngine(strings, self.context)
         result = parser.traverse(self.rule.condition)


### PR DESCRIPTION
Closes #45 

Using `anonymous_` as prefix should be pretty safe because normal string identifiers have to begin with a `$`
```
rule AnonymousStrings
{
    strings:
        $ = "dummy1"
        $ = "dummy2"
        $anonymous_0 = "aaaa"

    condition:
        1 of them
}
```
```
{'anonymous_0': <yaramod.PlainString object at 0x7fce88092180>, 'anonymous_1': <yaramod.PlainString object at 0x7fce88092298>, '$anonymous_0': <yaramod.PlainString object at 0x7fce88092308>}
```