### PR TITLE
Update CI configuration to run on external PRs

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -1,5 +1,11 @@
 name: "Code testing"
-on: [push]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   test_python_types:
     name: python mypy


### PR DESCRIPTION
Right now the CI will only run when someone pushes to the internal repo.

We also want to run CI on PRs from external forks.