### PR TITLE
Store the database index in ./index subdirectory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ config.py
 .idea
 .mypy_cache
 samples/
+index/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.py
 .idea
 .mypy_cache
 samples/
+index/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     - "9281:9281"
     volumes:
     - ./samples:/mnt/samples
+    - ./index:/var/lib/ursadb
   ursadb-cli:
     build:
       context: ursadb-cli/


### PR DESCRIPTION
Right now, the dabasase index is stored in a volume managed by docker.
This is easy to use (zero-configuration), but it can be hard to debug
and cause apparent loss of data when killing/moving the container.

Using a mounted directory is much more reliable.