### PR TITLE
Fix job sorting and legacy jobs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -137,7 +137,7 @@ def get_job(job_id: str) -> JobSchema:
         rule_author=job.get("rule_author", None),
         raw_yara=job.get("raw_yara", "ERROR"),
         submitted=job.get("submitted", 0),
-        priority=job.get("priority", "ERROR"),
+        priority=job.get("priority", "medium"),
         files_processed=job.get("files_processed", 0),
         total_files=job.get("total_files", 0),
     )
@@ -186,7 +186,8 @@ def user_jobs(name: str) -> List[JobSchema]:
 @app.get("/api/job", response_model=JobsSchema)
 def job_statuses() -> JobsSchema:
     jobs = [get_job(j) for j in redis.keys("job:*")]
-    return JobsSchema(jobs=sorted(jobs, key=lambda j: j.submitted))
+    jobs = sorted(jobs, key=lambda j: j.submitted, reverse=True)
+    return JobsSchema(jobs=jobs)
 
 
 @app.get("/api/backend", response_model=BackendStatusSchema)

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -12,12 +12,15 @@ function MatchItem(props) {
         </a>
     ));
 
-    const matches = Object.values(props.matches).map((v) => (
-        <span key={v}>
-            {" "}
-            <span className="badge badge-pill badge-primary">{v}</span>
-        </span>
-    ));
+    let matches = <span></span>;
+    if (props.matches) {
+        matches = Object.values(props.matches).map((v) => (
+            <span key={v}>
+                {" "}
+                <span className="badge badge-pill badge-primary">{v}</span>
+            </span>
+        ));
+    }
 
     const download_url =
         API_URL +

--- a/src/schema.py
+++ b/src/schema.py
@@ -8,7 +8,7 @@ class JobSchema(BaseModel):
     id: str
     status: str
     rule_name: str
-    rule_author: str
+    rule_author: Optional[str]
     raw_yara: str
     submitted: int
     priority: str


### PR DESCRIPTION
We want to sort jobs newest-first, not oldest-first.
Also, add a sane fallback for older jobs without priority.