### PR TITLE
Add pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Environment information**
+* Mquery version:
+* Installation method:
+  - [ ] Generic docker-compose
+  - [ ] Dev docker-compose
+  - [ ] Native (from source)
+  - [ ] Other (please explain)
+
+**Reproduction Steps**
+
+Please explain how can we reproduce your problem.
+
+
+**Expected behaviour**
+
+<!-- What did you expect to happen? -->
+
+
+**Actual behaviour the bug**
+
+<!-- What actually happened? -->
+
+
+**Screenshots**
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+
+**Additional context**
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ about: Create a report to help us improve
 
 **Reproduction Steps**
 
-Please explain how can we reproduce your problem.
+<!-- Please explain how can we reproduce your problem. -->
 
 
 **Expected behaviour**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,7 +5,8 @@ about: Create a report to help us improve
 ---
 
 **Environment information**
-* Mquery version:
+* Mquery version (from the /status page):
+* Ursadb version (from the /status page):
 * Installation method:
   - [ ] Generic docker-compose
   - [ ] Dev docker-compose

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest your idea
+
+---
+
+**Feature Category**
+
+- [ ] Correctness
+- [ ] User Interface / User Experience
+- [ ] Performance
+- [ ] Other (please explain)
+
+**Describe the problem.**
+
+<!-- A clear and concise description of the problem. -->
+
+**Describe the solution you'd like**
+
+<!-- If you have a solution in mind, please describe it. -->
+
+**Describe alternatives you've considered**
+
+<!-- Suggest any alternative solutions and workarounds (if applicable). -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,7 @@ about: Suggest your idea
 - [ ] Performance
 - [ ] Other (please explain)
 
-**Describe the problem.**
+**Describe the problem**
 
 <!-- A clear and concise description of the problem. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,9 +16,11 @@
 **Test plan**
 <!-- Explain how to test your changes -->
 
+<!-- After submitting, your code will be tested by the CI pipeline. Please
+ensure that all tests pass. If they don't at first, please update your code -->
+
+**Closing issues**
+
 <!-- Add in issue numbers related to this PR, if applicable -->
 
 Fixes: #issuenumber
-
-<!-- After submitting, your code will be tested by the CI pipeline. Please 
-ensure that all tests pass. If they don't at first, please update your code -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Thank you for contributing! -->
+<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->
+
+**Your checklist for this pull request**
+- [ ] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
+- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
+- [ ] I've added automated tests for my change (if applicable, optional)
+- [ ] I've updated documentation to reflect my change (if applicable)
+
+**What is the current behaviour?**
+<!-- Explain how the code works currently -->
+
+**What is the new behaviour?**
+<!-- Explain how the code works after your changes -->
+
+**Test plan**
+<!-- Explain how to test your changes -->
+
+<!-- Add in issue numbers related to this PR, if applicable -->
+
+Fixes: #issuenumber
+
+<!-- After submitting, your code will be tested by the CI pipeline. Please 
+ensure that all tests pass. If they don't at first, please update your code -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,4 @@ ensure that all tests pass. If they don't at first, please update your code -->
 
 <!-- Add in issue numbers related to this PR, if applicable -->
 
-Fixes: #issuenumber
+fixes #issuenumber


### PR DESCRIPTION
This was suggested by @ITAYC0HEN. PR templates I've created are
heavily based on Cutter's (but I was also inspired by other OS
projects.