### PR TITLE
Fix service startup order in docker-compose ymls

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
     - ./src:/usr/src/app/src
     depends_on:
       - "redis"
+      - "ursadb"
   dev-daemon:
     build:
       context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,8 @@ services:
     - dev-web
     volumes:
     - ./src/mqueryfront/src:/app/src
+    depends_on:
+      - "dev-web"
   dev-web:
     build:
       context: .
@@ -21,6 +23,8 @@ services:
     volumes:
     - ./samples:/mnt/samples
     - ./src:/usr/src/app/src
+    depends_on:
+      - "redis"
   dev-daemon:
     build:
       context: .
@@ -31,6 +35,9 @@ services:
     volumes:
     - ./samples:/mnt/samples
     - ./src:/usr/src/app/src
+    depends_on:
+      - "redis"
+      - "ursadb"
   ursadb:
     build:
       context: ursadb/
@@ -46,5 +53,7 @@ services:
     volumes:
     - ./samples:/mnt/samples
     command: tcp://ursadb:9281 --cmd "ping;"
+    depends_on:
+      - "ursadb"
   redis:
     image: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     - ./samples:/mnt/samples
     depends_on:
       - "redis"
+      - "ursadb"
   daemon:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     - redis
     volumes:
     - ./samples:/mnt/samples
+    depends_on:
+      - "redis"
   daemon:
     build:
       context: .
@@ -19,6 +21,9 @@ services:
     - ursadb
     volumes:
     - ./samples:/mnt/samples
+    depends_on:
+      - "redis"
+      - "ursadb"
   ursadb:
     build:
       context: ursadb/
@@ -35,5 +40,7 @@ services:
     volumes:
     - ./samples:/mnt/samples
     command: tcp://ursadb:9281 --cmd "ping;"
+    depends_on:
+      - "ursadb"
   redis:
     image: redis


### PR DESCRIPTION
Try to control service startup order. Otherwise they keep logging connection
errors for a first few seconds. This is not usually a problem (services
will connect eventually), but sifting through irrelevant errors when something
doesn't work may be confusing

This solution is not perfect (it doesn't check if service is ready, only
if the container started running), but it's better than nothing.