### PR TITLE
Fix problems with dev workflow on a clean clone

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,6 +29,7 @@ Docker compose dedicated for developers.
 ```
 git clone --recurse-submodules https://github.com/CERT-Polska/mquery.git
 cd mquery
+cp src/config.docker.py src/config.py
 # Optionally copy test files to ./samples directory
 docker-compose -f docker-compose.dev.yml up  # this will take a while
 ```


### PR DESCRIPTION
Some configuration was assumed when creating the first versin
of the documentation. While it may be obvious to system maintainers,
its unnecessary cause of problems for potential contributors.