### PR TITLE
Add an UI mock for storage management

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,6 +5,7 @@ import string
 import time
 
 import uvicorn
+from datetime import datetime
 from fastapi import FastAPI, Body, Query, HTTPException
 from starlette.requests import Request
 from starlette.responses import Response, FileResponse
@@ -28,6 +29,7 @@ from schema import (
     ParseResponseSchema,
     MatchesSchema,
     StatusSchema,
+    StorageSchema,
     UserSettingsSchema,
     UserInfoSchema,
     UserAuthSchema,
@@ -152,6 +154,21 @@ def job_info(job_id: str) -> JobSchema:
 def job_cancel(job_id: str) -> StatusSchema:
     redis.hmset("job:" + job_id, {"status": "cancelled"})
     return StatusSchema(status="ok")
+
+
+@app.get("/api/storage", response_model=List[StorageSchema])
+def storage_list() -> List[StorageSchema]:
+    return [
+        StorageSchema(
+            id="XYZ",
+            name="default",
+            path="/mnt/samples",
+            indexing_job_id=None,
+            last_update=datetime(2020, 4, 12),
+            taints=["malware"],
+            enabled=True,
+        )
+    ]
 
 
 @app.get("/api/user/settings", response_model=UserSettingsSchema)

--- a/src/mqueryfront/src/App.js
+++ b/src/mqueryfront/src/App.js
@@ -4,6 +4,8 @@ import Navigation from "./Navigation";
 import QueryPage from "./QueryPage";
 import RecentPage from "./RecentPage";
 import StatusPage from "./StatusPage";
+import StoragePage from "./StoragePage";
+import StorageAddPage from "./StorageAddPage";
 import "./App.css";
 
 class App extends Component {
@@ -16,6 +18,12 @@ class App extends Component {
                     <Route exact path="/" component={QueryPage} />
                     <Route path="/query/:hash" component={QueryPage} />
                     <Route exact path="/recent" component={RecentPage} />
+                    <Route exact path="/storage" component={StoragePage} />
+                    <Route
+                        exact
+                        path="/storage/add"
+                        component={StorageAddPage}
+                    />
                     <Route exact path="/status" component={StatusPage} />
                 </Switch>
             </div>

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -42,13 +42,13 @@ class Navigation extends Component {
                                 Recent jobs
                             </Link>
                         </li>
-                        {process.env.NODE_ENV == "development" ? (
+                        {process.env.NODE_ENV === "development" ? (
                             <li className="nav-item">
                                 <Link className="nav-link" to={"/storage"}>
                                     Storage
                                 </Link>
                             </li>
-                        ) : undefined}
+                        ) : null}
                         <li className="nav-item">
                             <Link className="nav-link" to={"/status"}>
                                 Status

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -42,6 +42,13 @@ class Navigation extends Component {
                                 Recent jobs
                             </Link>
                         </li>
+                        {process.env.NODE_ENV == "development" ? (
+                            <li className="nav-item">
+                                <Link className="nav-link" to={"/storage"}>
+                                    Storage
+                                </Link>
+                            </li>
+                        ) : undefined}
                         <li className="nav-item">
                             <Link className="nav-link" to={"/status"}>
                                 Status

--- a/src/mqueryfront/src/StorageAddPage.js
+++ b/src/mqueryfront/src/StorageAddPage.js
@@ -1,0 +1,58 @@
+import React, { Component } from "react";
+
+class StorageAddForm extends Component {
+    render() {
+        return (
+            <form>
+                <div class="form-group row">
+                    <label
+                        for="storageName"
+                        class="col-sm-2 col-form-label col-form-label"
+                    >
+                        Name
+                    </label>
+                    <div class="col-sm-10">
+                        <input
+                            type="text"
+                            class="form-control form-control"
+                            id="storageName"
+                            placeholder="Name for your new storage"
+                        />
+                    </div>
+                </div>
+                <div class="form-group row">
+                    <label
+                        for="storagePath"
+                        class="col-sm-2 col-form-label col-form-label"
+                    >
+                        Path
+                    </label>
+                    <div class="col-sm-10">
+                        <input
+                            type="text"
+                            class="form-control form-control"
+                            id="storagePath"
+                            placeholder="Root local filesystem path for storage"
+                        />
+                    </div>
+                </div>
+                <button class="btn btn-primary" type="submit">
+                    Submit
+                </button>
+            </form>
+        );
+    }
+}
+
+class StorageAddPage extends Component {
+    render() {
+        return (
+            <div className="container-fluid">
+                <h1 className="text-center mq-bottom">Configure Storage </h1>
+                <StorageAddForm />
+            </div>
+        );
+    }
+}
+
+export default StorageAddPage;

--- a/src/mqueryfront/src/StorageAddPage.js
+++ b/src/mqueryfront/src/StorageAddPage.js
@@ -4,39 +4,39 @@ class StorageAddForm extends Component {
     render() {
         return (
             <form>
-                <div class="form-group row">
+                <div className="form-group row">
                     <label
                         for="storageName"
-                        class="col-sm-2 col-form-label col-form-label"
+                        className="col-sm-2 col-form-label col-form-label"
                     >
                         Name
                     </label>
-                    <div class="col-sm-10">
+                    <div className="col-sm-10">
                         <input
                             type="text"
-                            class="form-control form-control"
+                            className="form-control form-control"
                             id="storageName"
                             placeholder="Name for your new storage"
                         />
                     </div>
                 </div>
-                <div class="form-group row">
+                <div className="form-group row">
                     <label
                         for="storagePath"
-                        class="col-sm-2 col-form-label col-form-label"
+                        className="col-sm-2 col-form-label col-form-label"
                     >
                         Path
                     </label>
-                    <div class="col-sm-10">
+                    <div className="col-sm-10">
                         <input
                             type="text"
-                            class="form-control form-control"
+                            className="form-control form-control"
                             id="storagePath"
                             placeholder="Root local filesystem path for storage"
                         />
                     </div>
                 </div>
-                <button class="btn btn-primary" type="submit">
+                <button className="btn btn-primary" type="submit">
                     Submit
                 </button>
             </form>

--- a/src/mqueryfront/src/StorageList.js
+++ b/src/mqueryfront/src/StorageList.js
@@ -26,22 +26,45 @@ class StorageRow extends Component {
     }
 
     render() {
+        var taintTags = this.props.taints.map((taint) => (
+            <span>
+                {" "}
+                <span
+                    class="badge badge-primary"
+                    data-toggle="tooltip"
+                    title={`New indexed files are tagged with "${taint}"`}
+                >
+                    {taint}
+                </span>
+            </span>
+        ));
+
+        var actionButtons = (
+            <div>
+                <button
+                    type="button"
+                    class="btn btn-secondary btn-sm"
+                    data-toggle="tooltip"
+                    title="Reindex this dataset now"
+                >
+                    Reindex
+                </button>{" "}
+                <button
+                    type="button"
+                    class="btn btn-danger btn-sm"
+                    data-toggle="tooltip"
+                    title="Stop watching the dataset (keep indexed files)"
+                >
+                    Delete
+                </button>
+            </div>
+        );
+
         return (
             <tr>
                 <td>
                     <code>{this.props.name}</code>
-                    {this.props.taints.map((taint) => (
-                        <span>
-                            {" "}
-                            <span
-                                class="badge badge-primary"
-                                data-toggle="tooltip"
-                                title={`New indexed files are tagged with "${taint}"`}
-                            >
-                                {taint}
-                            </span>
-                        </span>
-                    ))}
+                    {taintTags}
                 </td>
                 <td>
                     <code>{this.props.path}</code>
@@ -50,24 +73,7 @@ class StorageRow extends Component {
                     {new Date(this.props.lastUpdate).toLocaleDateString()}{" "}
                     {this.getWatchedBadge()}
                 </td>
-                <td>
-                    <button
-                        type="button"
-                        class="btn btn-secondary btn-sm"
-                        data-toggle="tooltip"
-                        title="Reindex this dataset now"
-                    >
-                        Reindex
-                    </button>
-                    <button
-                        type="button"
-                        class="btn btn-danger btn-sm"
-                        data-toggle="tooltip"
-                        title="Stop watching the dataset (keep indexed files)"
-                    >
-                        Delete
-                    </button>
-                </td>
+                <td>{actionButtons}</td>
             </tr>
         );
     }

--- a/src/mqueryfront/src/StorageList.js
+++ b/src/mqueryfront/src/StorageList.js
@@ -6,7 +6,7 @@ class StorageRow extends Component {
         if (this.props.enabled) {
             return (
                 <span
-                className="badge badge-success"
+                    className="badge badge-success"
                     data-toggle="tooltip"
                     title="This location is watched and indexed automatically"
                 >
@@ -16,7 +16,7 @@ class StorageRow extends Component {
         }
         return (
             <span
-            className="badge badge-secondary"
+                className="badge badge-secondary"
                 data-toggle="tooltip"
                 title="This location is not indexed automatically"
             >

--- a/src/mqueryfront/src/StorageList.js
+++ b/src/mqueryfront/src/StorageList.js
@@ -6,7 +6,7 @@ class StorageRow extends Component {
         if (this.props.enabled) {
             return (
                 <span
-                    class="badge badge-success"
+                className="badge badge-success"
                     data-toggle="tooltip"
                     title="This location is watched and indexed automatically"
                 >
@@ -16,7 +16,7 @@ class StorageRow extends Component {
         }
         return (
             <span
-                class="badge badge-secondary"
+            className="badge badge-secondary"
                 data-toggle="tooltip"
                 title="This location is not indexed automatically"
             >
@@ -26,11 +26,11 @@ class StorageRow extends Component {
     }
 
     render() {
-        var taintTags = this.props.taints.map((taint) => (
+        let taintTags = this.props.taints.map((taint) => (
             <span>
                 {" "}
                 <span
-                    class="badge badge-primary"
+                    className="badge badge-primary"
                     data-toggle="tooltip"
                     title={`New indexed files are tagged with "${taint}"`}
                 >
@@ -39,11 +39,11 @@ class StorageRow extends Component {
             </span>
         ));
 
-        var actionButtons = (
+        let actionButtons = (
             <div>
                 <button
                     type="button"
-                    class="btn btn-secondary btn-sm"
+                    className="btn btn-secondary btn-sm"
                     data-toggle="tooltip"
                     title="Reindex this dataset now"
                 >
@@ -51,7 +51,7 @@ class StorageRow extends Component {
                 </button>{" "}
                 <button
                     type="button"
-                    class="btn btn-danger btn-sm"
+                    className="btn btn-danger btn-sm"
                     data-toggle="tooltip"
                     title="Stop watching the dataset (keep indexed files)"
                 >

--- a/src/mqueryfront/src/StorageList.js
+++ b/src/mqueryfront/src/StorageList.js
@@ -1,0 +1,109 @@
+import React, { Component } from "react";
+import ErrorBoundary from "./ErrorBoundary";
+
+class StorageRow extends Component {
+    getWatchedBadge() {
+        if (this.props.enabled) {
+            return (
+                <span
+                    class="badge badge-success"
+                    data-toggle="tooltip"
+                    title="This location is watched and indexed automatically"
+                >
+                    watched
+                </span>
+            );
+        }
+        return (
+            <span
+                class="badge badge-secondary"
+                data-toggle="tooltip"
+                title="This location is not indexed automatically"
+            >
+                disabled
+            </span>
+        );
+    }
+
+    render() {
+        return (
+            <tr>
+                <td>
+                    <code>{this.props.name}</code>
+                    {this.props.taints.map((taint) => (
+                        <span>
+                            {" "}
+                            <span
+                                class="badge badge-primary"
+                                data-toggle="tooltip"
+                                title={`New indexed files are tagged with "${taint}"`}
+                            >
+                                {taint}
+                            </span>
+                        </span>
+                    ))}
+                </td>
+                <td>
+                    <code>{this.props.path}</code>
+                </td>
+                <td>
+                    {new Date(this.props.lastUpdate).toLocaleDateString()}{" "}
+                    {this.getWatchedBadge()}
+                </td>
+                <td>
+                    <button
+                        type="button"
+                        class="btn btn-secondary btn-sm"
+                        data-toggle="tooltip"
+                        title="Reindex this dataset now"
+                    >
+                        Reindex
+                    </button>
+                    <button
+                        type="button"
+                        class="btn btn-danger btn-sm"
+                        data-toggle="tooltip"
+                        title="Stop watching the dataset (keep indexed files)"
+                    >
+                        Delete
+                    </button>
+                </td>
+            </tr>
+        );
+    }
+}
+
+class StorageList extends Component {
+    render() {
+        const storageRows = this.props.storage.map((storage) => (
+            <StorageRow
+                name={storage.name}
+                path={storage.path}
+                taints={storage.taints}
+                lastUpdate={storage.last_update}
+                enabled={storage.enabled}
+                key={storage.id}
+            />
+        ));
+
+        return (
+            <ErrorBoundary error={this.props.error}>
+                <div className="table-responsive">
+                    <table className="table table-striped table-bordered">
+                        <thead>
+                            <tr>
+                                <th>name</th>
+                                <th>path</th>
+                                <th>last update</th>
+                                <th>actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>{storageRows}</tbody>
+                    </table>
+                </div>
+            </ErrorBoundary>
+        );
+    }
+}
+
+export default StorageList;

--- a/src/mqueryfront/src/StoragePage.js
+++ b/src/mqueryfront/src/StoragePage.js
@@ -1,0 +1,53 @@
+import React, { Component } from "react";
+import ErrorBoundary from "./ErrorBoundary";
+import StorageList from "./StorageList";
+import axios from "axios";
+import { API_URL } from "./config";
+import { Link } from "react-router-dom";
+
+class StoragePage extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            storage: [],
+            error: null,
+        };
+    }
+
+    componentDidMount() {
+        axios
+            .get(API_URL + "/storage")
+            .then((response) => {
+                this.setState({ storage: response.data });
+            })
+            .catch((error) => {
+                this.setState({ error: error });
+            });
+    }
+
+    render() {
+        return (
+            <ErrorBoundary error={this.state.error}>
+                <div className="container-fluid">
+                    <h1 className="text-center mq-bottom">
+                        Storage{" "}
+                        <Link
+                            className="nav-link"
+                            to={"/storage/add"}
+                            type="button"
+                            class="btn btn-success btn-sm"
+                            data-toggle="tooltip"
+                            title="Configure a new storage location"
+                        >
+                            +
+                        </Link>
+                    </h1>
+                    <StorageList storage={this.state.storage} />
+                </div>
+            </ErrorBoundary>
+        );
+    }
+}
+
+export default StoragePage;

--- a/src/mqueryfront/src/StoragePage.js
+++ b/src/mqueryfront/src/StoragePage.js
@@ -36,7 +36,7 @@ class StoragePage extends Component {
                             className="nav-link"
                             to={"/storage/add"}
                             type="button"
-                            class="btn btn-success btn-sm"
+                            className="btn btn-success btn-sm"
                             data-toggle="tooltip"
                             title="Configure a new storage location"
                         >

--- a/src/schema.py
+++ b/src/schema.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import List, Dict, Optional
+from datetime import datetime
 
 from pydantic import BaseModel
 
@@ -18,6 +19,16 @@ class JobSchema(BaseModel):
 
 class JobsSchema(BaseModel):
     jobs: List[JobSchema]
+
+
+class StorageSchema(BaseModel):
+    id: str
+    name: str
+    path: str
+    indexing_job_id: Optional[str]
+    last_update: datetime
+    taints: List[str]
+    enabled: bool
 
 
 class TaskSchema(BaseModel):


### PR DESCRIPTION
I got bored and did a thing.

Currently mquery doesn't manage its own files, which is weird given its goals.
We didn't even realise this, because we configured reindexing once, and forgot
about it. In practice though, mquery should keep track of configured folders
and automatically reindex them - without someone hacking a cron job for this.

This PR is only an UI mock, but I still want to merge this (after getting a
proper feedback of course) - for once I'll try to avoid dumping a 500 line
diff on the reviewer. It's OK to merge because it's behind a "feature toggle"
aka NODE_ENV being production - so it won't affect non-developers.

By the way, this is a second iteration. The first one was lost, because I
kept my code in /tmp and did a hasty reboot. Argh.

Related to #30, but not a complete fix... yet.

Screenshot of the storage list view:

![ss](https://user-images.githubusercontent.com/7026881/79058023-9bc45600-7c68-11ea-99f5-6deaa6a718ab.png)

And storage configuration form:

![ss](https://user-images.githubusercontent.com/7026881/79057969-9286b980-7c67-11ea-8688-4f8dc4623c98.png)
