### PR TITLE
WIP: Collapsible query and minor UI improvements

### DIFF
--- a/src/mqueryfront/src/App.css
+++ b/src/mqueryfront/src/App.css
@@ -4,10 +4,16 @@
 }
 
 .mquery-scroll-matches {
-    height: calc(100vh - 95px);
+    height: calc(100vh - 235px);
     overflow-y: scroll;
 }
 
 .mquery-scroll-matches td {
     word-break: break-all;
+}
+
+.is-collapsed {
+    -webkit-transform: translateX(-100%);
+    transform: translateX(-100%);
+    position: absolute;
 }

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -48,7 +48,7 @@ class Navigation extends Component {
                             </Link>
                         </li>
                     </ul>
-                    <ul className="navbar-nav mr-auto navbar-right">
+                    <ul className="navbar-nav navbar-right">
                         <li className="nav-item nav-right">
                             <a className="nav-link" href="/docs">
                                 API Docs

--- a/src/mqueryfront/src/QueryField.js
+++ b/src/mqueryfront/src/QueryField.js
@@ -106,7 +106,7 @@ class QueryField extends Component {
                 <div className="btn-group mb-1" role="group">
                     <button
                         type="button"
-                        className="btn btn-success btn-lg"
+                        className="btn btn-success btn-sm"
                         onClick={(event) =>
                             this.handleQuery(event, "query", "medium")
                         }
@@ -153,7 +153,7 @@ class QueryField extends Component {
                     </div>
                     {this.state.isLocked ? (
                         <button
-                            className="btn btn-secondary btn-lg"
+                            className="btn btn-secondary btn-sm"
                             name="clone"
                             type="submit"
                             onClick={this.handleEdit}
@@ -162,7 +162,7 @@ class QueryField extends Component {
                         </button>
                     ) : (
                         <button
-                            className="btn btn-secondary btn-lg"
+                            className="btn btn-secondary btn-sm"
                             name="parse"
                             type="submit"
                             onClick={(event) =>

--- a/src/mqueryfront/src/QueryPage.js
+++ b/src/mqueryfront/src/QueryPage.js
@@ -17,6 +17,7 @@ class QueryPage extends Component {
 
         this.state = {
             mode: "query",
+            collapsed: false,
             qhash: qhash,
             rawYara: "",
             queryPlan: null,
@@ -27,6 +28,7 @@ class QueryPage extends Component {
         this.updateQhash = this.updateQhash.bind(this);
         this.updateQueryError = this.updateQueryError.bind(this);
         this.updateQueryPlan = this.updateQueryPlan.bind(this);
+        this.collapsePane = this.collapsePane.bind(this);
     }
 
     componentDidMount() {
@@ -66,6 +68,7 @@ class QueryPage extends Component {
             this.props.history.push("/");
         } else {
             this.props.history.push("/query/" + newQhash);
+            this.collapsePane();
         }
 
         this.setState({
@@ -76,7 +79,6 @@ class QueryPage extends Component {
             matches: [],
             job: [],
         });
-
         this.loadMatches();
     }
 
@@ -153,6 +155,12 @@ class QueryPage extends Component {
         });
     }
 
+    collapsePane() {
+        this.setState((prevState) => ({
+            collapsed: !prevState.collapsed,
+        }));
+    }
+
     render() {
         var queryParse = (
             <QueryParseStatus
@@ -162,16 +170,30 @@ class QueryPage extends Component {
             />
         );
         var queryResults = (
-            <QueryResultsStatus
-                qhash={this.state.qhash}
-                job={this.state.job}
-                matches={this.state.matches}
-            />
+            <div>
+                <button
+                    type="button"
+                    className="btn btn-primary btn-sm pull-left mr-4"
+                    onClick={this.collapsePane}
+                >
+                    <span className="fa fa-align-left" />{" "}
+                    {this.state.collapsed ? "Show" : "Hide"} query
+                </button>
+                <QueryResultsStatus
+                    qhash={this.state.qhash}
+                    job={this.state.job}
+                    matches={this.state.matches}
+                />
+            </div>
         );
         return (
             <div className="container-fluid">
-                <div className="row">
-                    <div className="col-md-6">
+                <div className="row wrapper">
+                    <div
+                        className={
+                            this.state.collapsed ? "is-collapsed" : "col-md-5"
+                        }
+                    >
                         <QueryField
                             rawYara={this.state.rawYara}
                             isLoading={this.state.qhash && !this.state.rawYara}
@@ -182,7 +204,11 @@ class QueryPage extends Component {
                             updateQueryError={this.updateQueryError}
                         />
                     </div>
-                    <div className="col-md-6" id="status-col">
+                    <div
+                        className={
+                            this.state.collapsed ? "col-md-12" : "col-md-7"
+                        }
+                    >
                         {this.state.mode === "query"
                             ? queryParse
                             : queryResults}

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -3,203 +3,212 @@ import axios from "axios/index";
 import { API_URL } from "./config";
 
 function MatchItem(props) {
-  const metadata = Object.values(props.meta).map((v) => (
-    <a href={v.url}>
-      {" "}
-      <span className="badge badge-pill badge-warning">
-        {v.display_text}
-      </span>
-    </a>
-  ));
-
-  let matches = <span></span>;
-  if (props.matches) {
-    matches = Object.values(props.matches).map((v) => (
-      <span key={v}>
-        {" "}
-        <span className="badge badge-pill badge-primary ml-1 pull-right ">{v}</span>
-      </span>
+    const metadata = Object.values(props.meta).map((v) => (
+        <a href={v.url}>
+            {" "}
+            <span className="badge badge-pill badge-warning">
+                {v.display_text}
+            </span>
+        </a>
     ));
-  }
 
-  const download_url =
-    API_URL +
-    "/download?job_id=" +
-    encodeURIComponent(props.qhash) +
-    "&ordinal=" +
-    encodeURIComponent(props.ordinal) +
-    "&file_path=" +
-    encodeURIComponent(props.file);
+    let matches = <span></span>;
+    if (props.matches) {
+        matches = Object.values(props.matches).map((v) => (
+            <span key={v}>
+                {" "}
+                <span className="badge badge-pill badge-primary ml-1 pull-right ">{v}</span>
+            </span>
+        ));
+    }
 
-  return (
-    <tr>
-      <td>
-        <a href={download_url}>{props.file}</a>
-        {matches}
-        {metadata}
-      </td>
-    </tr>
-  );
+    const download_url =
+        API_URL +
+        "/download?job_id=" +
+        encodeURIComponent(props.qhash) +
+        "&ordinal=" +
+        encodeURIComponent(props.ordinal) +
+        "&file_path=" +
+        encodeURIComponent(props.file);
+
+    return (
+        <tr>
+            <td>
+                <a href={download_url}>{props.file}</a>
+                {matches}
+                {metadata}
+            </td>
+        </tr>
+    );
 }
 
 function ReturnExpiredJob(job_error) {
-  return (
-    <div className="mquery-scroll-matches">
-      {job_error ? (
-        <div className="alert alert-danger">{job_error}</div>
-      ) : (
-        <div />
-      )}
-      <div style={{ marginTop: "55px" }}>
-        Search results expired. Please run the query once again.
-      </div>
-    </div>
-  );
+    return (
+        <div className="mquery-scroll-matches">
+            {job_error ? (
+                <div className="alert alert-danger">{job_error}</div>
+            ) : (
+                <div />
+            )}
+            <div style={{ marginTop: "55px" }}>
+                Search results expired. Please run the query once again.
+            </div>
+        </div>
+    );
 }
 
 class QueryResultsStatus extends Component {
-  constructor(props) {
-    super(props);
+    constructor(props) {
+        super(props);
 
-    this.handleCancelJob = this.handleCancelJob.bind(this);
-  }
-
-  handleCancelJob() {
-    axios.delete(API_URL + "/job/" + this.props.qhash);
-  }
-
-  renderSwitchStatus(status) {
-    switch (status) {
-      case "done":
-        return "success";
-      case "cancelled":
-        return "danger";
-      case "expired":
-        return "warning";
-      case "processing":
-      case "querying":
-        return "info";
-      default:
-        return "info";
-    }
-  }
-
-  render() {
-    if (this.props.job && this.props.job.error) {
-      return (
-        <div className="alert alert-danger">
-          <h2>Error occurred</h2>
-          {this.props.job.error}
-        </div>
-      );
+        this.handleCancelJob = this.handleCancelJob.bind(this);
     }
 
-    if (!this.props.job) {
-      return (
-        <div>
-          <h2>
-            <i className="fa fa-spinner fa-spin spin-big" /> Loading...
-          </h2>
-        </div>
-      );
+    handleCancelJob() {
+        axios.delete(API_URL + "/job/" + this.props.qhash);
     }
 
-    let progress = Math.floor(
-      (this.props.job.files_processed * 100) / this.props.job.total_files
-    );
-    let processed =
-      this.props.job.files_processed + " / " + this.props.job.total_files;
-    let cancel = (
-      <button
-        className="btn btn-danger btn-sm"
-        onClick={this.handleCancelJob}
-      >
-        cancel
-      </button>
-    );
-
-    if (!this.props.job.total_files && this.props.job.status !== "done") {
-      progress = 0;
-      processed = "-";
+    renderSwitchStatus(status) {
+        switch (status) {
+            case "done":
+                return "success";
+            case "cancelled":
+                return "danger";
+            case "expired":
+                return "warning";
+            case "processing":
+            case "querying":
+                return "info";
+            default:
+                return "info";
+        }
     }
 
-    const matches = this.props.matches.map((match, index) => (
-      <MatchItem
-        {...match}
-        qhash={this.props.qhash}
-        key={match.file}
-        ordinal={index}
-      />
-    ));
+    render() {
+        if (this.props.job && this.props.job.error) {
+            return (
+                <div className="alert alert-danger">
+                    <h2>Error occurred</h2>
+                    {this.props.job.error}
+                </div>
+            );
+        }
 
-    let progressBg = "bg-" + this.renderSwitchStatus(this.props.job.status);
+        if (!this.props.job) {
+            return (
+                <div>
+                    <h2>
+                    <i className="fa fa-spinner fa-spin spin-big" /> Loading...
+                    </h2>
+                </div>
+            );
+        }
 
-    let finishedStatuses = ["done", "cancelled", "expired"];
-    if (finishedStatuses.includes(this.props.job.status)) {
-        cancel = <span />;
+        let progress = Math.floor(
+            (this.props.job.files_processed * 100) / this.props.job.total_files
+        );
+        let processed =
+            this.props.job.files_processed + " / " + this.props.job.total_files;
+        let cancel = (
+            <button
+                className="btn btn-danger btn-sm"
+                onClick={this.handleCancelJob}
+            >
+                cancel
+            </button>
+        );
+
+        if (!this.props.job.total_files && this.props.job.status !== "done") {
+            progress = 0;
+            processed = "-";
+        }
+
+        const matches = this.props.matches.map((match, index) => (
+            <MatchItem
+                {...match}
+                qhash={this.props.qhash}
+                key={match.file}
+                ordinal={index}
+            />
+        ));
+
+        let progressBg = "bg-" + this.renderSwitchStatus(this.props.job.status);
+
+        let finishedStatuses = ["done", "cancelled", "expired"];
+        if (finishedStatuses.includes(this.props.job.status)) {
+            cancel = <span />;
+        }
+
+        const lenMatches = this.props.matches.length;
+
+        if (this.props.job.status === "expired") {
+            return ReturnExpiredJob(this.props.job.error);
+        }
+
+        let results = <div />;
+
+        if (lenMatches === 0 && this.props.job.status === "done") {
+            progress = 100;
+            results = <div className="alert alert-info">No matches found.</div>;
+        } else if (lenMatches !== 0) {
+            results = (
+                <div class="mquery-scroll-matches">
+                    <table className={"table table-striped table-bordered"}>
+                        <thead>
+                            <tr>
+                                <th>Matches</th>
+                            </tr>
+                        </thead>
+                        <tbody>{matches}</tbody>
+                    </table>
+                </div>
+            );
+        }
+
+        return (
+            <div>
+                <div className="progress" style={{ marginTop: "55px" }}>
+                    <div
+                        className={"progress-bar " + progressBg}
+                        role="progressbar"
+                        style={{ width: progress + "%" }}
+                    >
+                        {progress}%
+                    </div>
+                </div>
+                <div className="row m-0 pt-3">
+                    <div className="col-md-2">
+                        <p>
+                            Matches: <span>{lenMatches}</span>
+                        </p>
+                    </div>
+                    <div className="col-md-3">
+                        Status:{" "}
+                        <span
+                            className={
+                                "badge badge-" +
+                                this.renderSwitchStatus(this.props.job.status)
+                            }
+                        >
+                            {this.props.job.status}
+                        </span>
+                    </div>
+                    <div className="col-md-5">
+                        Processed: <span>{processed}</span>
+                    </div>
+                    <div className="col-md-2">{cancel}</div>
+                </div>
+                {this.props.job.error ? (
+                    <div className="alert alert-danger">
+                        {this.props.job.error}
+                    </div>
+                ) : (
+                    <div />
+                )}
+                {results}
+            </div>
+        );
     }
-
-    const lenMatches = this.props.matches.length;
-
-    if (this.props.job.status === "expired") {
-      return ReturnExpiredJob(this.props.job.error);
-    }
-
-    let results = <div />;
-
-    if (lenMatches === 0 && this.props.job.status === "done") {
-      progress = 100;
-      results = <div className="alert alert-info">No matches found.</div>;
-    } else if (lenMatches !== 0) {
-      results = (
-        <div class="mquery-scroll-matches">
-          <table className={"table table-striped table-bordered"}>
-            <thead>
-              <tr>
-                <th>Matches</th>
-              </tr>
-            </thead>
-            <tbody>{matches}</tbody>
-          </table>
-        </div>
-      );
-    }
-
-    return (
-      <div>
-        <div className="progress" style={{ marginTop: "55px" }}>
-          <div
-            className={"progress-bar " + progressBg}
-            role="progressbar"
-            style={{ width: progress + "%" }}
-          >
-            {progress}%
-          </div>
-        </div>
-        <div className="row m-0 pt-3">
-          <div className="col-md-2">
-            <p>
-              Matches: <span>{lenMatches}</span>
-            </p>
-          </div>
-          <div className="col-md-3">
-            Status:{" "}
-            <span className={"badge badge-" + this.renderSwitchStatus(this.props.job.status)}>{this.props.job.status}</span>
-          </div>
-          <div className="col-md-5">
-            Processed: <span>{processed}</span>
-          </div>
-          <div className="col-md-2">{cancel}</div>
-        </div>
-        {this.props.job.error ? (
-          <div className="alert alert-danger">{this.props.job.error}</div>
-        ) : (
-          <div />
-        )}
-        {results}
-      </div>
-    );
-  }
 }
 
 export default QueryResultsStatus;

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -17,7 +17,9 @@ function MatchItem(props) {
         matches = Object.values(props.matches).map((v) => (
             <span key={v}>
                 {" "}
-                <span className="badge badge-pill badge-primary ml-1 pull-right ">{v}</span>
+                <span className="badge badge-pill badge-primary ml-1 pull-right ">
+                    {v}
+                </span>
             </span>
         ));
     }
@@ -98,7 +100,8 @@ class QueryResultsStatus extends Component {
             return (
                 <div>
                     <h2>
-                    <i className="fa fa-spinner fa-spin spin-big" /> Loading...
+                        <i className="fa fa-spinner fa-spin spin-big" />{" "}
+                        Loading...
                     </h2>
                 </div>
             );

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -3,196 +3,203 @@ import axios from "axios/index";
 import { API_URL } from "./config";
 
 function MatchItem(props) {
-    const metadata = Object.values(props.meta).map((v) => (
-        <a href={v.url}>
-            {" "}
-            <span className="badge badge-pill badge-warning">
-                {v.display_text}
-            </span>
-        </a>
+  const metadata = Object.values(props.meta).map((v) => (
+    <a href={v.url}>
+      {" "}
+      <span className="badge badge-pill badge-warning">
+        {v.display_text}
+      </span>
+    </a>
+  ));
+
+  let matches = <span></span>;
+  if (props.matches) {
+    matches = Object.values(props.matches).map((v) => (
+      <span key={v}>
+        {" "}
+        <span className="badge badge-pill badge-primary ml-1 pull-right ">{v}</span>
+      </span>
     ));
+  }
 
-    let matches = <span></span>;
-    if (props.matches) {
-        matches = Object.values(props.matches).map((v) => (
-            <span key={v}>
-                {" "}
-                <span className="badge badge-pill badge-primary">{v}</span>
-            </span>
-        ));
-    }
+  const download_url =
+    API_URL +
+    "/download?job_id=" +
+    encodeURIComponent(props.qhash) +
+    "&ordinal=" +
+    encodeURIComponent(props.ordinal) +
+    "&file_path=" +
+    encodeURIComponent(props.file);
 
-    const download_url =
-        API_URL +
-        "/download?job_id=" +
-        encodeURIComponent(props.qhash) +
-        "&ordinal=" +
-        encodeURIComponent(props.ordinal) +
-        "&file_path=" +
-        encodeURIComponent(props.file);
-
-    return (
-        <tr>
-            <td>
-                <a href={download_url}>{props.file}</a>
-                {matches}
-                {metadata}
-            </td>
-        </tr>
-    );
+  return (
+    <tr>
+      <td>
+        <a href={download_url}>{props.file}</a>
+        {matches}
+        {metadata}
+      </td>
+    </tr>
+  );
 }
 
 function ReturnExpiredJob(job_error) {
-    return (
-        <div className="mquery-scroll-matches">
-            {job_error ? (
-                <div className="alert alert-danger">{job_error}</div>
-            ) : (
-                <div />
-            )}
-            <div style={{ marginTop: "55px" }}>
-                Search results expired. Please run the query once again.
-            </div>
-        </div>
-    );
+  return (
+    <div className="mquery-scroll-matches">
+      {job_error ? (
+        <div className="alert alert-danger">{job_error}</div>
+      ) : (
+        <div />
+      )}
+      <div style={{ marginTop: "55px" }}>
+        Search results expired. Please run the query once again.
+      </div>
+    </div>
+  );
 }
 
 class QueryResultsStatus extends Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.handleCancelJob = this.handleCancelJob.bind(this);
+    this.handleCancelJob = this.handleCancelJob.bind(this);
+  }
+
+  handleCancelJob() {
+    axios.delete(API_URL + "/job/" + this.props.qhash);
+  }
+
+  renderSwitchStatus(status) {
+    switch (status) {
+      case "done":
+        return "success";
+      case "cancelled":
+        return "danger";
+      case "expired":
+        return "warning";
+      case "processing":
+      case "querying":
+        return "info";
+      default:
+        return "info";
+    }
+  }
+
+  render() {
+    if (this.props.job && this.props.job.error) {
+      return (
+        <div className="alert alert-danger">
+          <h2>Error occurred</h2>
+          {this.props.job.error}
+        </div>
+      );
     }
 
-    handleCancelJob() {
-        axios.delete(API_URL + "/job/" + this.props.qhash);
+    if (!this.props.job) {
+      return (
+        <div>
+          <h2>
+            <i className="fa fa-spinner fa-spin spin-big" /> Loading...
+          </h2>
+        </div>
+      );
     }
 
-    render() {
-        if (this.props.job && this.props.job.error) {
-            return (
-                <div className="alert alert-danger">
-                    <h2>Error occurred</h2>
-                    {this.props.job.error}
-                </div>
-            );
-        }
+    let progress = Math.floor(
+      (this.props.job.files_processed * 100) / this.props.job.total_files
+    );
+    let processed =
+      this.props.job.files_processed + " / " + this.props.job.total_files;
+    let cancel = (
+      <button
+        className="btn btn-danger btn-sm"
+        onClick={this.handleCancelJob}
+      >
+        cancel
+      </button>
+    );
 
-        if (!this.props.job) {
-            return (
-                <div>
-                    <h2>
-                        <i className="fa fa-spinner fa-spin spin-big" />{" "}
-                        Loading...
-                    </h2>
-                </div>
-            );
-        }
-
-        let progress = Math.floor(
-            (this.props.job.files_processed * 100) / this.props.job.total_files
-        );
-        let processed =
-            this.props.job.files_processed + " / " + this.props.job.total_files;
-        let cancel = (
-            <button
-                className="btn btn-danger btn-sm"
-                onClick={this.handleCancelJob}
-            >
-                cancel
-            </button>
-        );
-
-        if (!this.props.job.total_files && this.props.job.status !== "done") {
-            progress = 0;
-            processed = "-";
-        }
-
-        const matches = this.props.matches.map((match, index) => (
-            <MatchItem
-                {...match}
-                qhash={this.props.qhash}
-                key={match.file}
-                ordinal={index}
-            />
-        ));
-
-        let progressBg = "bg-info";
-
-        if (this.props.job.status === "done") {
-            progressBg = "bg-success";
-            cancel = <span />;
-        } else if (this.props.job.status === "cancelled") {
-            progressBg = "bg-danger";
-            cancel = <span />;
-        } else if (this.props.job.status === "expired") {
-            progressBg = "bg-secondary";
-            cancel = <span />;
-        }
-
-        const lenMatches = this.props.matches.length;
-
-        if (this.props.job.status === "expired") {
-            return ReturnExpiredJob(this.props.job.error);
-        }
-
-        let results = <div />;
-
-        if (lenMatches === 0 && this.props.job.status === "done") {
-            progress = 100;
-            results = <div className="alert alert-info">No matches found.</div>;
-        } else if (lenMatches !== 0) {
-            results = (
-                <table className={"table table-striped table-bordered"}>
-                    <thead>
-                        <tr>
-                            <th>Matches</th>
-                        </tr>
-                    </thead>
-                    <tbody>{matches}</tbody>
-                </table>
-            );
-        }
-
-        return (
-            <div className="mquery-scroll-matches">
-                <div className="progress" style={{ marginTop: "55px" }}>
-                    <div
-                        className={"progress-bar " + progressBg}
-                        role="progressbar"
-                        style={{ width: progress + "%" }}
-                    >
-                        {progress}%
-                    </div>
-                </div>
-                <div className="row m-0 pt-3">
-                    <div className="col-md-2">
-                        <p>
-                            Matches: <span>{lenMatches}</span>
-                        </p>
-                    </div>
-                    <div className="col-md-3">
-                        Status:{" "}
-                        <span className="badge badge-dark">
-                            {this.props.job.status}
-                        </span>
-                    </div>
-                    <div className="col-md-5">
-                        Processed: <span>{processed}</span>
-                    </div>
-                    <div className="col-md-2">{cancel}</div>
-                </div>
-                {this.props.job.error ? (
-                    <div className="alert alert-danger">
-                        {this.props.job.error}
-                    </div>
-                ) : (
-                    <div />
-                )}
-                {results}
-            </div>
-        );
+    if (!this.props.job.total_files && this.props.job.status !== "done") {
+      progress = 0;
+      processed = "-";
     }
+
+    const matches = this.props.matches.map((match, index) => (
+      <MatchItem
+        {...match}
+        qhash={this.props.qhash}
+        key={match.file}
+        ordinal={index}
+      />
+    ));
+
+    let progressBg = "bg-" + this.renderSwitchStatus(this.props.job.status);
+
+    let finishedStatuses = ["done", "cancelled", "expired"];
+    if (finishedStatuses.includes(this.props.job.status)) {
+        cancel = <span />;
+    }
+
+    const lenMatches = this.props.matches.length;
+
+    if (this.props.job.status === "expired") {
+      return ReturnExpiredJob(this.props.job.error);
+    }
+
+    let results = <div />;
+
+    if (lenMatches === 0 && this.props.job.status === "done") {
+      progress = 100;
+      results = <div className="alert alert-info">No matches found.</div>;
+    } else if (lenMatches !== 0) {
+      results = (
+        <div class="mquery-scroll-matches">
+          <table className={"table table-striped table-bordered"}>
+            <thead>
+              <tr>
+                <th>Matches</th>
+              </tr>
+            </thead>
+            <tbody>{matches}</tbody>
+          </table>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <div className="progress" style={{ marginTop: "55px" }}>
+          <div
+            className={"progress-bar " + progressBg}
+            role="progressbar"
+            style={{ width: progress + "%" }}
+          >
+            {progress}%
+          </div>
+        </div>
+        <div className="row m-0 pt-3">
+          <div className="col-md-2">
+            <p>
+              Matches: <span>{lenMatches}</span>
+            </p>
+          </div>
+          <div className="col-md-3">
+            Status:{" "}
+            <span className={"badge badge-" + this.renderSwitchStatus(this.props.job.status)}>{this.props.job.status}</span>
+          </div>
+          <div className="col-md-5">
+            Processed: <span>{processed}</span>
+          </div>
+          <div className="col-md-2">{cancel}</div>
+        </div>
+        {this.props.job.error ? (
+          <div className="alert alert-danger">{this.props.job.error}</div>
+        ) : (
+          <div />
+        )}
+        {results}
+      </div>
+    );
+  }
 }
 
 export default QueryResultsStatus;


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

This PR is a work-in-progress. I applied the prettier for formatting and it looks great on VSCODE, but Github shows huge diff in the code. I'll investigate this tomorrow.

**What is the current behavior?**
<!-- Explain how the code works currently -->

- The query pane takes a lot of space when showing the results
- Multiple buttons are too big and steal screen space
- Matched rules are not aligned in results view
- "API Docs" button was stuck in the middle of the screen
- The status label was shown in gray
- Scrollbar contained the progress bar, # of matched samples and status

**What is the new behavior?**

_Click on the GIF to see it in full size_
![demo_collapse_query](https://user-images.githubusercontent.com/20182642/79076576-e34bf000-7d03-11ea-941c-d8154a91dc35.gif)

- Implemented a button to collapse and uncollapse the Query view
  - The collapse button is not visible when no query was executed (e.g writing new query)
  - After clicking the "Query" button, the Query view will collapse since it is less likely to be used
  - When entering an executed query from the /recent page, the Query view will be collapsed
- Implemented a generic function to color both the Status label and the progress bar based on the job's status
- The matched rules labels are now pulled to the right and more spacious
- The buttons in the Query view are smaller now
- The scroll bar is now available only in the Matches table. Hence, the status view with the progress bar 
stays at top
- The "API Docs" button was wrongly aligned. Now it is pulled to the right, assuming the author didn't mean to pull it to the left.


**Test plan**
TODO

**Closing issues**

TODO


