### PR TITLE
Fix index files location in ursadb.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,6 +39,7 @@ services:
     - "9281:9281"
     volumes:
     - ./samples:/mnt/samples
+    - ./index:/var/lib/ursadb
   ursadb-cli:
     build:
       context: ursadb-cli/


### PR DESCRIPTION
Right now we use still use docker volume in dev docker compose.
This PR fixes that.

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Files are stored in a docker volume

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Files are stored in the `./index` subdirectory in the repo

**Test plan**
<!-- Explain how to test your changes -->

Start the db in the normal mode, index some files, switch to a dev docker-compose, everything is still indexed.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

