### PR TITLE
UI improvements to status page

### DIFF
--- a/src/mqueryfront/src/App.css
+++ b/src/mqueryfront/src/App.css
@@ -17,3 +17,29 @@
     transform: translateX(-100%);
     position: absolute;
 }
+
+.accordion-toggle {
+    cursor: pointer;
+    position: relative;
+}
+
+.accordion-toggle::after {
+    content: "\f107";
+    color: rgb(134, 134, 134);
+    padding: 1rem;
+    right: 0px;
+    position: absolute;
+    font-family: "FontAwesome";
+}
+
+.accordion-toggle[aria-expanded="true"]::after {
+    content: "\f106";
+}
+
+.table-topology tbody tr:nth-child(4n + 1) {
+    background: rgba(0, 0, 0, 0.05);
+}
+
+.table-topology tbody tr:nth-child(2n) {
+    background: rgba(0, 0, 0, 0.02);
+}

--- a/src/mqueryfront/src/BackendStatus.js
+++ b/src/mqueryfront/src/BackendStatus.js
@@ -25,15 +25,15 @@ class BackendStatus extends Component {
 
         return (
             <div>
-                <h2 className="text-center mq-bottom">current connections</h2>
+                <h2 className="text-center mq-bottom">Current Connections</h2>
                 <div className="table-responsive">
                     <table className="table table-striped table-bordered">
                         <thead>
                             <tr>
-                                <th>id</th>
-                                <th>conn</th>
-                                <th>request</th>
-                                <th>progress</th>
+                                <th>ID</th>
+                                <th>Connection</th>
+                                <th>Request</th>
+                                <th>Progress</th>
                             </tr>
                         </thead>
                         <tbody>{backendJobRows}</tbody>

--- a/src/mqueryfront/src/DatabaseTopology.js
+++ b/src/mqueryfront/src/DatabaseTopology.js
@@ -7,8 +7,12 @@ import { API_URL } from "./config";
 
 class DatasetRow extends Component {
     render() {
-        return (
-            <tr>
+        return [
+            <tr
+                data-toggle="collapse"
+                data-target={"#collapsed_" + this.props.id}
+                class="accordion-toggle"
+            >
                 <td>
                     <code>{this.props.id}</code>
                     {this.props.taints.map((taint) => (
@@ -21,18 +25,30 @@ class DatasetRow extends Component {
                     ))}
                 </td>
                 <td>
-                    {this.props.indexes.map((x) => {
-                        return (
-                            <div key={x.type} className="h6">
-                                <code>{x.type}</code> (
-                                {filesize(x.size, { standard: "iec" })})
-                            </div>
-                        );
-                    })}
+                    {this.props.file_count} files (
+                    {filesize(this.props.size, { standard: "iec" })})
                 </td>
-                <td>{filesize(this.props.size, { standard: "iec" })}</td>
-            </tr>
-        );
+            </tr>,
+            <tr>
+                <td colspan="2" class="hiddentablerow p-0">
+                    <div
+                        class="accordian-body collapse"
+                        id={"collapsed_" + this.props.id}
+                    >
+                        <div class="p-3">
+                            {this.props.indexes.map((x) => {
+                                return (
+                                    <div key={x.type}>
+                                        <code>{x.type}</code> (
+                                        {filesize(x.size, { standard: "iec" })})
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                </td>
+            </tr>,
+        ];
     }
 }
 
@@ -92,12 +108,11 @@ class DatabaseTopology extends Component {
                     </button>
                 </h2>
                 <div className="table-responsive">
-                    <table className="table table-striped table-bordered">
+                    <table className="table table-bordered table-topology">
                         <thead>
                             <tr>
                                 <th>dataset id</th>
-                                <th>index types</th>
-                                <th>size</th>
+                                <th> # files (size)</th>
                             </tr>
                         </thead>
                         <tbody>{datasetRows}</tbody>

--- a/src/mqueryfront/src/DatabaseTopology.js
+++ b/src/mqueryfront/src/DatabaseTopology.js
@@ -95,7 +95,7 @@ class DatabaseTopology extends Component {
         return (
             <ErrorBoundary error={this.state.error}>
                 <h2 className="text-center mq-bottom">
-                    topology
+                    Topology
                     <button
                         className="btn btn-danger btn-sm float-right"
                         name="query"
@@ -104,15 +104,15 @@ class DatabaseTopology extends Component {
                         onClick={this.runCompactAll}
                         title="Compact the db. Warning: this may take a long time"
                     >
-                        db compact
+                        DB Compact
                     </button>
                 </h2>
                 <div className="table-responsive">
                     <table className="table table-bordered table-topology">
                         <thead>
                             <tr>
-                                <th>dataset id</th>
-                                <th> # files (size)</th>
+                                <th>Dataset ID</th>
+                                <th> # Files (size)</th>
                             </tr>
                         </thead>
                         <tbody>{datasetRows}</tbody>

--- a/src/mqueryfront/src/VersionStatus.js
+++ b/src/mqueryfront/src/VersionStatus.js
@@ -6,13 +6,13 @@ class VersionStatus extends Component {
 
         return (
             <div>
-                <h2 className="text-center mq-bottom">system version</h2>
+                <h2 className="text-center mq-bottom">System Version</h2>
                 <div className="table-responsive">
                     <table className="table table-striped table-bordered">
                         <thead>
                             <tr>
-                                <th>component</th>
-                                <th>version</th>
+                                <th>Component</th>
+                                <th>Version</th>
                             </tr>
                         </thead>
                         <tbody>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)


**What is the current behaviour?**
This pull request continues the great work done by @JaroPowerH and tries to solve two things.
First, the Topology table in the status is showing four columns. I think that there is extra info in there and sometimes even redundancy.
Second, there is a mixture of Capitalisation and lower-case in titles and table headers.

**What is the new behaviour?**
The PR implements an accordion feature in the table, to not show the index types by default. It also sums up sizes where needed. Trying to focus on what matters to the user.

Secondly, the PR capitalizes the Status page wherever it is needed.

![mquery_show_topology_collapse3](https://user-images.githubusercontent.com/20182642/79221550-afd1a880-7e5e-11ea-83d7-5db100bf9de0.gif)

Don't get scared by the 5 new CSS properties. They are used to design the table to look better. The creation of a new `td` broke the table-stripped so I had to strip it by myself. It's a common practice.
Another common practice that applied is the toggled arrow in the collapsible rows.

**Test plan**
- Fetch the PR locally and start up mquery
- See that no regression was introduced when displaying the Topology table
- Add multiple indexes to a dataset and see that all of them are clearly visible and that their sizes are correct
- Make sure that no typo was introduce when capitalizing the row headers

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

None
