### PR TITLE
Use .env file to point docker-compose to sample dirs

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+SAMPLES_DIR=./samples
+INDEX_DIR=./index

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.py
 .mypy_cache
 samples/
 index/
+.env

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,10 @@ Quick build & run with [docker compose](https://docs.docker.com/compose/).
 git clone --recurse-submodules https://github.com/CERT-Polska/mquery.git
 cd mquery
 mkdir samples
-# Copy your malware samples to ./samples directory in the cloned repository
+# now set SAMPLES_DIR to a directory with your files, and INDEX_DIR to
+# empty directory for database files to live in. By default database will
+# expect files in ./samples directory, and keep index in ./index.
+vim .env
 docker-compose up --scale daemon=3  # this will take a while
 ```
 
@@ -30,7 +33,10 @@ Docker compose dedicated for developers.
 git clone --recurse-submodules https://github.com/CERT-Polska/mquery.git
 cd mquery
 cp src/config.docker.py src/config.py
-# Optionally copy test files to ./samples directory
+# now set SAMPLES_DIR to a directory with your files, and INDEX_DIR to
+# empty directory for database files to live in. By default database will
+# expect files in ./samples directory, and keep index in ./index.
+vim .env
 docker-compose -f docker-compose.dev.yml up  # this will take a while
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ The easiest way to start is by using `docker-compose` from the source:
 ```
 git clone --recurse-submodules https://github.com/CERT-Polska/mquery.git
 cd mquery
-# Copy your malware samples to ./samples directory in the cloned repository
+# now set SAMPLES_DIR to a directory with your files, and INDEX_DIR to
+# empty directory for database files to live in. By default database will
+# expect files in ./samples directory, and keep index in ./index.
+vim .env  
 docker-compose up --scale daemon=3  # building the images will take a while
 ```
 
@@ -53,7 +56,8 @@ $ sudo docker-compose exec ursadb ursacli
 ursadb> index "/mnt/samples";
 ```
 
-In a default docker-compose deployment, `/mnt/samples` point to `./samples` directory relative to the repository root.
+In a default docker-compose deployment, `/mnt/samples` point to the configured
+`SAMPLES_DIR` from the `.env` file.
 
 The command will track the progress.
 Wait until it's finished (this can take a while).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,7 +21,7 @@ services:
     links:
     - redis
     volumes:
-    - ./samples:/mnt/samples
+    - "${SAMPLES_DIR}:/mnt/samples"
     - ./src:/usr/src/app/src
     depends_on:
       - "redis"
@@ -34,7 +34,7 @@ services:
     - redis
     - ursadb
     volumes:
-    - ./samples:/mnt/samples
+    - "${SAMPLES_DIR}:/mnt/samples"
     - ./src:/usr/src/app/src
     depends_on:
       - "redis"
@@ -46,7 +46,7 @@ services:
     ports:
     - "9281:9281"
     volumes:
-    - ./samples:/mnt/samples
-    - ./index:/var/lib/ursadb
+    - "${SAMPLES_DIR}:/mnt/samples"
+    - "${INDEX_DIR}:/var/lib/ursadb"
   redis:
     image: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     links:
     - redis
     volumes:
-    - ./samples:/mnt/samples
+    - "${SAMPLES_DIR}:/mnt/samples"
     depends_on:
       - "redis"
       - "ursadb"
@@ -21,7 +21,7 @@ services:
     - redis
     - ursadb
     volumes:
-    - ./samples:/mnt/samples
+    - "${SAMPLES_DIR}:/mnt/samples"
     depends_on:
       - "redis"
       - "ursadb"
@@ -32,7 +32,7 @@ services:
     ports:
     - "9281:9281"
     volumes:
-    - ./samples:/mnt/samples
-    - ./index:/var/lib/ursadb
+    - "${SAMPLES_DIR}:/mnt/samples"
+    - "${INDEX_DIR}:/var/lib/ursadb"
   redis:
     image: redis


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Right now we force the user to keep samples in the ./samples dir, and index in
the ./index directory. They can change the docker-compose.yml file, but the
changes may be overwritten by or conflict with a future git pull. Using
.env files is a standard solution of this problem and we should do this.


**What is the new behaviour?**
We use .env files

**Test plan**
- Edit .env file and set INDEX_DIR and SAMPLES_DIR to empty directories on the fs
- Start mquery
- Mquery should see SAMPLES_DIR as `/mnt/samples` and INDEX_DIR should should contain indexes.,

If you get warnings about volumes not being recreated, try `--renew-anon-volumes` switch:
```
sudo docker-compose -f docker-compose.dev.yml up --renew-anon-volumes
```
(if anon volume was used by the docker-compose earlier, it won't pick up the docker compose changes without this switch). 

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

I believe this change finally..

fixes #69
