### PR TITLE
Add a database model for storage

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,7 +1,6 @@
 import os
 
 import uvicorn
-from datetime import datetime
 from fastapi import FastAPI, Body, Query, HTTPException
 from starlette.requests import Request
 from starlette.responses import Response, FileResponse
@@ -32,6 +31,8 @@ from schema import (
     UserAuthSchema,
     BackendStatusSchema,
     BackendStatusDatasetsSchema,
+    StorageRequestSchema,
+    StorageCreateRequestSchema,
 )
 
 db = Database()
@@ -121,17 +122,31 @@ def job_cancel(job_id: str) -> StatusSchema:
 
 @app.get("/api/storage", response_model=List[StorageSchema])
 def storage_list() -> List[StorageSchema]:
-    return [
-        StorageSchema(
-            id="XYZ",
-            name="default",
-            path="/mnt/samples",
-            indexing_job_id=None,
-            last_update=datetime(2020, 4, 12),
-            taints=["malware"],
-            enabled=True,
-        )
-    ]
+    return db.get_storages()
+
+
+@app.post("/api/storage", response_model=StatusSchema)
+def storage_add(data: StorageCreateRequestSchema = Body(...)) -> StatusSchema:
+    db.create_storage(data.name, data.path)
+    return StatusSchema(status="ok")
+
+
+@app.post("/api/storage/enable", response_model=StatusSchema)
+def storage_enable(data: StorageRequestSchema = Body(...)) -> StatusSchema:
+    db.enable_storage(data.id)
+    return StatusSchema(status="ok")
+
+
+@app.post("/api/storage/disable", response_model=StatusSchema)
+def storage_disable(data: StorageRequestSchema = Body(...)) -> StatusSchema:
+    db.disable_storage(data.id)
+    return StatusSchema(status="ok")
+
+
+@app.post("/api/storage/delete", response_model=StatusSchema)
+def storage_delete(data: StorageRequestSchema = Body(...)) -> StatusSchema:
+    db.delete_storage(data.id)
+    return StatusSchema(status="ok")
 
 
 @app.get("/api/user/settings", response_model=UserSettingsSchema)

--- a/src/mqueryfront/src/StorageAddPage.js
+++ b/src/mqueryfront/src/StorageAddPage.js
@@ -1,9 +1,47 @@
 import React, { Component } from "react";
+import axios from "axios";
+import { API_URL } from "./config";
+import ErrorBoundary from "./ErrorBoundary";
 
 class StorageAddForm extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            storageName: "",
+            storagePath: "",
+            error: null,
+        };
+
+        this.handleInputChange = this.handleInputChange.bind(this);
+    }
+
+    handleInputChange(event) {
+        const target = event.target;
+        this.setState({
+            [target.name]: target.value,
+        });
+    }
+
+    handleAdd(event) {
+        axios
+            .create()
+            .post(API_URL + "/storage", {
+                name: this.state.storageName,
+                path: this.state.storagePath,
+            })
+            .then(() => {
+                this.props.history.push("/storage");
+            })
+            .catch((error) => {
+                this.setState({ error: error });
+            });
+    }
+
     render() {
         return (
-            <form>
+            <div>
+                <ErrorBoundary error={this.state.error}>{null}</ErrorBoundary>
                 <div className="form-group row">
                     <label
                         for="storageName"
@@ -15,8 +53,10 @@ class StorageAddForm extends Component {
                         <input
                             type="text"
                             className="form-control form-control"
-                            id="storageName"
+                            name="storageName"
                             placeholder="Name for your new storage"
+                            onChange={this.handleInputChange}
+                            value={this.state.storageName}
                         />
                     </div>
                 </div>
@@ -31,15 +71,20 @@ class StorageAddForm extends Component {
                         <input
                             type="text"
                             className="form-control form-control"
-                            id="storagePath"
+                            name="storagePath"
                             placeholder="Root local filesystem path for storage"
+                            onChange={this.handleInputChange}
+                            value={this.state.storagePath}
                         />
                     </div>
                 </div>
-                <button className="btn btn-primary" type="submit">
+                <button
+                    className="btn btn-primary"
+                    onClick={() => this.handleAdd()}
+                >
                     Submit
                 </button>
-            </form>
+            </div>
         );
     }
 }
@@ -49,7 +94,7 @@ class StorageAddPage extends Component {
         return (
             <div className="container-fluid">
                 <h1 className="text-center mq-bottom">Configure Storage </h1>
-                <StorageAddForm />
+                <StorageAddForm history={this.props.history} />
             </div>
         );
     }

--- a/src/mqueryfront/src/StorageList.js
+++ b/src/mqueryfront/src/StorageList.js
@@ -1,7 +1,23 @@
 import React, { Component } from "react";
+import axios from "axios";
+import { API_URL } from "./config";
 import ErrorBoundary from "./ErrorBoundary";
 
 class StorageRow extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            storageName: "",
+            storagePath: "",
+            error: null,
+        };
+
+        this.handleEnable = this.handleEnable.bind(this);
+        this.handleDisable = this.handleDisable.bind(this);
+        this.handleDelete = this.handleDelete.bind(this);
+    }
+
     getWatchedBadge() {
         if (this.props.enabled) {
             return (
@@ -25,6 +41,33 @@ class StorageRow extends Component {
         );
     }
 
+    handleEnable() {
+        axios
+            .create()
+            .post(API_URL + "/storage/enable", {
+                id: this.props.id,
+            })
+            .then(() => this.props.reload());
+    }
+
+    handleDisable() {
+        axios
+            .create()
+            .post(API_URL + "/storage/disable", {
+                id: this.props.id,
+            })
+            .then(() => this.props.reload());
+    }
+
+    handleDelete() {
+        axios
+            .create()
+            .post(API_URL + "/storage/delete", {
+                id: this.props.id,
+            })
+            .then(() => this.props.reload());
+    }
+
     render() {
         let taintTags = this.props.taints.map((taint) => (
             <span>
@@ -39,21 +82,42 @@ class StorageRow extends Component {
             </span>
         ));
 
-        let actionButtons = (
-            <div>
+        let toggleButton;
+        if (this.props.enabled) {
+            toggleButton = (
                 <button
                     type="button"
                     className="btn btn-secondary btn-sm"
                     data-toggle="tooltip"
-                    title="Reindex this dataset now"
+                    title="Disable reindexing"
+                    onClick={this.handleDisable}
                 >
-                    Reindex
-                </button>{" "}
+                    Disable
+                </button>
+            );
+        } else {
+            toggleButton = (
+                <button
+                    type="button"
+                    className="btn btn-success btn-sm"
+                    data-toggle="tooltip"
+                    title="Enable reindexing"
+                    onClick={this.handleEnable}
+                >
+                    Enable
+                </button>
+            );
+        }
+
+        let actionButtons = (
+            <div>
+                {toggleButton}{" "}
                 <button
                     type="button"
                     className="btn btn-danger btn-sm"
                     data-toggle="tooltip"
                     title="Stop watching the dataset (keep indexed files)"
+                    onClick={this.handleDelete}
                 >
                     Delete
                 </button>
@@ -83,12 +147,14 @@ class StorageList extends Component {
     render() {
         const storageRows = this.props.storage.map((storage) => (
             <StorageRow
+                id={storage.id}
                 name={storage.name}
                 path={storage.path}
                 taints={storage.taints}
                 lastUpdate={storage.last_update}
                 enabled={storage.enabled}
                 key={storage.id}
+                reload={this.props.reload}
             />
         ));
 

--- a/src/mqueryfront/src/StoragePage.js
+++ b/src/mqueryfront/src/StoragePage.js
@@ -13,9 +13,15 @@ class StoragePage extends Component {
             storage: [],
             error: null,
         };
+
+        this.reloadStorage = this.reloadStorage.bind(this);
     }
 
     componentDidMount() {
+        this.reloadStorage();
+    }
+
+    reloadStorage() {
         axios
             .get(API_URL + "/storage")
             .then((response) => {
@@ -43,7 +49,10 @@ class StoragePage extends Component {
                             +
                         </Link>
                     </h1>
-                    <StorageList storage={this.state.storage} />
+                    <StorageList
+                        reload={this.reloadStorage}
+                        storage={this.state.storage}
+                    />
                 </div>
             </ErrorBoundary>
         );

--- a/src/schema.py
+++ b/src/schema.py
@@ -32,6 +32,15 @@ class StorageSchema(BaseModel):
     enabled: bool
 
 
+class StorageCreateRequestSchema(BaseModel):
+    name: str
+    path: str
+
+
+class StorageRequestSchema(BaseModel):
+    id: str
+
+
 class TaskSchema(BaseModel):
     connection_id: str
     epoch_ms: int


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional) (feature not ready yet)
- [ ] I've updated documentation to reflect my change (if applicable) (feature not ready yet)

**What is the current behaviour?**
Storage view is only a mock

**What is the new behaviour?**
User can create and remove storage from the web UI

**Test plan**
- start mquery
- browse to http://localhost/storage
- add a new storage or two
- verify that it was added
- ensure that deleting storage works
- ensure that toggling storage works

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

not yet
