### PR TITLE
Add a script for local indexing

### DIFF
--- a/src/reindex_local.py
+++ b/src/reindex_local.py
@@ -6,8 +6,8 @@ import argparse
 from typing import Set, Iterator, Tuple, List
 from pathlib import Path
 from lib.ursadb import UrsaDb
-from tempfile import NamedTemporaryFile
 from multiprocessing import Pool
+from tempfile import NamedTemporaryFile
 
 
 def all_indexed_files(ursa: UrsaDb) -> Set[str]:

--- a/src/reindex_local.py
+++ b/src/reindex_local.py
@@ -15,7 +15,7 @@ def all_indexed_files(ursa: UrsaDb) -> Set[str]:
     result: Set[str] = set()
     while True:
         pop_result = ursa.pop(iterator, 5000)
-        if pop_result.should_drop_iterator:
+        if pop_result.iterator_empty:
             break
         for fpath in pop_result.files:
             result.add(fpath)

--- a/src/reindex_local.py
+++ b/src/reindex_local.py
@@ -90,6 +90,11 @@ def main() -> None:
         type=int,
         default=2,
     )
+    parser.add_argument(
+        "--dry-run",
+        help="Don't index, only print filenames.",
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
@@ -107,8 +112,9 @@ def main() -> None:
     current_batch = 10 ** 20  # As good as infinity.
     new_files = 0
     for f in find_new_files(fileset, args.path, path_mount):
-        print(f)
-        continue
+        if args.dry_run:
+            print(f)
+            continue
         if current_batch > args.batch:
             current_batch = 0
             if tmpfile:
@@ -126,6 +132,9 @@ def main() -> None:
     logging.info(
         "Got %s files in %s batches to index.", new_files, len(tmpfiles)
     )
+    if args.dry_run:
+        return
+
     indexing_jobs = []
     for tmppath in tmpfiles:
         mounted_name = os.path.join(


### PR DESCRIPTION
Doing a lot of logic in ursadb `index` command didn't turn out well. Lift it
to python to allow for more parallelism in an user friendly way.

In the future, cache indexed files on disk to decrease RAM usage.

Requires `nocheck` support in ursadb.

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [n/a] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [n/a?] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable) - will update later, when this becomes the recommended method

**What is the current behaviour?**

Indexing files does not parallelise well and uses a lot of RAM

**What is the new behaviour?**

Indexing is easy to scale to many processes, and RAM usage can be optimised later too.

**Test plan**

I've tested like this

```
python3 src/reindex_local.py samples/ --ursadb tcp://ursadb:9281 --tmpdir /usr/src/app/index/ --tmpdir-mount /var/lib/ursadb --path-mount /mnt/samples --batch 1 --workers 3
```

There are a lot of parameters here, because of the filesystem split. In case of bare metal ursadb deployment this would reduce to:

```
python3 src/reindex_local samples [plus optionally --batch and --workers]
```

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**
