### PR TITLE
Fix/implement ursaexpression literal

### DIFF
--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -2,7 +2,6 @@ import argparse
 import itertools
 import re
 from typing import Dict, List, Optional
-
 from yaramod import (  # type: ignore
     AndExpression,
     EqExpression,
@@ -46,6 +45,14 @@ class UrsaExpression:
 
     def __init__(self, query: str) -> None:
         self.query = query
+
+    @classmethod
+    def literal(cls, some_string):
+        return cls(f"{{{some_string}}}")
+
+    @classmethod
+    def literal_to_hex(cls, some_string):
+        return cls(f"{{{some_string.hex()}}}")
 
     @classmethod
     def and_(cls, *args: "UrsaExpression") -> "UrsaExpression":
@@ -136,15 +143,15 @@ def ursify_hex(hex_str: str) -> UrsaExpression:
             output.append(part[last_end:])
 
     core = "} & {".join(output)
-    return UrsaExpression(f"{{{core}}}")
+    return UrsaExpression.literal(core)
 
 
 def ursify_plain_string(string: PlainString) -> UrsaExpression:
     text_ascii = string.pure_text
     text_wide = bytes(x for y in text_ascii for x in [y, 0])
 
-    ursa_ascii = UrsaExpression(f"{{{text_ascii.hex()}}}")
-    ursa_wide = UrsaExpression(f"{{{text_wide.hex()}}}")
+    ursa_ascii = UrsaExpression.literal_to_hex(text_ascii)
+    ursa_wide = UrsaExpression.literal_to_hex(text_wide)
 
     if string.is_wide and not string.is_ascii:
         return ursa_wide
@@ -164,9 +171,9 @@ def ursify_xor_string(string: PlainString) -> UrsaExpression:
         xored_wide = bytes(x ^ xor_key for y in text_ascii for x in [y, 0])
 
         if string.is_ascii:
-            xored_strings.append(UrsaExpression(f"{{{xored_ascii.hex()}}}"))
+            xored_strings.append(UrsaExpression.literal_to_hex(xored_ascii))
         if string.is_wide:
-            xored_strings.append(UrsaExpression(f"{{{xored_wide.hex()}}}"))
+            xored_strings.append(UrsaExpression.literal_to_hex(xored_wide))
 
     return UrsaExpression.or_(*xored_strings)
 

--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -142,8 +142,7 @@ def ursify_hex(hex_str: str) -> UrsaExpression:
         if last_end is not None:
             output.append(part[last_end:])
 
-    core = "} & {".join(output)
-    return UrsaExpression.literal(core)
+    return UrsaExpression.and_(*[UrsaExpression.literal(f) for f in output])
 
 
 def ursify_plain_string(string: PlainString) -> UrsaExpression:

--- a/src/tests/Dockerfile
+++ b/src/tests/Dockerfile
@@ -4,4 +4,5 @@ COPY src/tests/requirements.txt /app/requirements.txt
 RUN pip3 install -r /app/requirements.txt
 COPY src/ /app/
 WORKDIR /app
-CMD ["python", "-m", "pytest", "--log-cli-level=INFO", "tests/"]
+#CMD ["python", "-m", "pytest", "--log-cli-level=INFO", "tests/"]
+CMD ["python", "-m", "pytest", "-s", "tests/"]

--- a/src/tests/Dockerfile
+++ b/src/tests/Dockerfile
@@ -4,5 +4,4 @@ COPY src/tests/requirements.txt /app/requirements.txt
 RUN pip3 install -r /app/requirements.txt
 COPY src/ /app/
 WORKDIR /app
-#CMD ["python", "-m", "pytest", "--log-cli-level=INFO", "tests/"]
-CMD ["python", "-m", "pytest", "-s", "tests/"]
+CMD ["python", "-m", "pytest", "--log-cli-level=INFO", "tests/"]

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest==5.4.1
 pytest-timeout==1.3.4
 pyzmq==19.0.0
+yaramod

--- a/src/tests/test_yaraparse.py
+++ b/src/tests/test_yaraparse.py
@@ -1,0 +1,27 @@
+"""
+Unit tests for yaraparse
+"""
+
+from lib.yaraparse import ursify_hex
+from lib.yaraparse import ursify_plain_string
+from yaramod import PlainString
+from yaramod import YaraRuleBuilder
+import yaramod
+
+
+def test_literal_with_hex():
+    hex_str = "3F2504E0"
+    result = ursify_hex(hex_str)
+
+    assert result.query == "{3F2504E0}"
+
+
+def test_literal_without_hex():
+    rule = yaramod.YaraRuleBuilder().with_plain_string("$str", "abc")
+    print(rule.plain_string)
+
+    ascii_str = PlainString("$str", "abc")
+
+    result = ursify_plain_string(ascii_str)
+
+    print(f"Result: {result.query}")

--- a/src/tests/test_yaraparse.py
+++ b/src/tests/test_yaraparse.py
@@ -11,7 +11,7 @@ def test_literal():
     hex_str = "3F2504E0"
     result = ursify_hex(hex_str)
 
-    assert result.query == "{3F2504E0}"
+    assert result.query == "({3F2504E0})"
 
 
 def test_literal_to_hex():

--- a/src/tests/test_yaraparse.py
+++ b/src/tests/test_yaraparse.py
@@ -4,24 +4,23 @@ Unit tests for yaraparse
 
 from lib.yaraparse import ursify_hex
 from lib.yaraparse import ursify_plain_string
-from yaramod import PlainString
-from yaramod import YaraRuleBuilder
 import yaramod
 
 
-def test_literal_with_hex():
+def test_literal():
     hex_str = "3F2504E0"
     result = ursify_hex(hex_str)
 
     assert result.query == "{3F2504E0}"
 
 
-def test_literal_without_hex():
-    rule = yaramod.YaraRuleBuilder().with_plain_string("$str", "abc")
-    print(rule.plain_string)
+def test_literal_to_hex():
+    rule = yaramod.YaraRuleBuilder().with_plain_string("$str", "abc").get()
 
-    ascii_str = PlainString("$str", "abc")
+    new_file = yaramod.YaraFileBuilder()
+    yara_file = new_file.with_rule(rule).get()
 
+    ascii_str = yara_file.rules[0].strings[0]
     result = ursify_plain_string(ascii_str)
 
-    print(f"Result: {result.query}")
+    assert result.query == "{616263}"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
f"{}" need to be added every time.

**What is the new behaviour?**
Logic stays unchanged. The only difference is that it's just sufficient to give pure string in literal function instead of adding "f{}".

**Test plan**
Run tests from src/tests

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #99
