### PR TITLE
Different colors for priority icons

### DIFF
--- a/src/mqueryfront/src/components/PriorityIcon.js
+++ b/src/mqueryfront/src/components/PriorityIcon.js
@@ -9,16 +9,28 @@ import PropTypes from "prop-types";
 
 const PriorityIcon = (props) => {
     let icon;
-    if (props.priority === "low") icon = faAngleDown;
-    else if (props.priority === "medium") icon = faAngleUp;
-    else if (props.priority === "high") icon = faAngleDoubleUp;
-    else return null;
+    let color;
+
+    if (props.priority === "low") {
+        icon = faAngleDown;
+        color = "green";
+    } else if (props.priority === "medium") {
+        icon = faAngleUp;
+        color = "orange";
+    } else if (props.priority === "high") {
+        icon = faAngleDoubleUp;
+        color = "red";
+    } else return null;
 
     return (
         <span data-toggle="tooltip" title={props.priority}>
-            <FontAwesomeIcon icon={icon} size="1x" color="red" />
+            <FontAwesomeIcon icon={icon} size={props.size} color={color} />
         </span>
     );
+};
+
+PriorityIcon.defaultProps = {
+    size: "1x",
 };
 
 PriorityIcon.propTypes = {


### PR DESCRIPTION
Priority icon should be colored: high-red, medium-orange, low-green.
See picture: 
![Screenshot from 2020-05-02 22-53-05](https://user-images.githubusercontent.com/63407380/80891972-df3e3d00-8cc7-11ea-8a76-6710ad010bbb.png)
