### PR TITLE
Allow to set required plugins that must be present in all active agents to process the query

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import List, Dict, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class JobSchema(BaseModel):
@@ -55,6 +55,7 @@ class QueryRequestSchema(BaseModel):
     taint: Optional[str]
     priority: Optional[str]
     method: str
+    required_plugins: List[str] = Field([])
 
 
 class QueryResponseSchema(BaseModel):


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the current behaviour?**
- If plugin is not present nor configured in all agents: metadata will be applied only for part of matches. For Malwarecage integration we need to guarantee that user will see all the results and will be informed whether this requirement can't be fulfilled due to misconfiguration.

**What is the new behaviour?**
- Added `required_plugins` field to the `QueryRequestSchema` which contains list of required plugins. If at least one of plugins is not active in any of agents: query will fail with error "Agent {agent} doesn't support required plugins: {list of unsupported plugins}"

**TODO**
- [x] Due to lazy configuration reload technique: if we provide configuration for newly installed plugin, all agents need to process at least one Yara hit to reload configuration and set the plugin state. Until then: query with additional requirement will always fail. We need to provide better reloading strategy in separate PR. (#145)

Related with #67 