### PR TITLE
Request plugin configuration to be reloaded on demand

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -6,7 +6,7 @@ import json
 import sys
 from lib.ursadb import UrsaDb
 from util import setup_logging
-from typing import Any, List, Optional
+from typing import Any, List
 from lib.yaraparse import parse_yara, combine_rules
 from db import AgentTask, JobId, Database, MatchInfo, TaskType
 from cachetools import cached, LRUCache
@@ -56,7 +56,6 @@ class Agent:
         self.ursa_url = ursa_url
         self.db = db
         self.ursa = UrsaDb(self.ursa_url)
-        self.plugin_config_version: Optional[str] = None
         self.active_plugins: List[MetadataPlugin] = []
 
     def __search_task(self, job_id: JobId) -> None:

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -232,11 +232,14 @@ class Agent:
                 self.plugin_config_version
                 == self.db.get_plugin_config_version()
             ):
-                # This should never happen and suggests that version is not updated properly.
-                raise RuntimeError(
+                # This should never happen and suggests that there is bug somewhere
+                # and version was not updated properly.
+                logging.error(
                     "Critical error: Requested to reload configuration, but "
-                    "configuration present in database is still the same."
+                    "configuration present in database is still the same (%s).",
+                    self.plugin_config_version,
                 )
+                return
             logging.info("Configuration changed - reloading plugins.")
             # Request next agent to reload the configuration
             self.db.reload_configuration(self.plugin_config_version)

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -229,17 +229,22 @@ class Agent:
         :raises RuntimeError: Task with unsupported type given.
         """
         if task.type == TaskType.RELOAD:
-            if self.plugin_config_version == self.db.get_plugin_config_version():
+            if (
+                self.plugin_config_version
+                == self.db.get_plugin_config_version()
+            ):
                 # This should never happen and suggests that version is not updated properly.
-                raise RuntimeError("Critical error: Requested to reload configuration, but "
-                                   "configuration present in database is still the same.")
+                raise RuntimeError(
+                    "Critical error: Requested to reload configuration, but "
+                    "configuration present in database is still the same."
+                )
             logging.info("Configuration changed - reloading plugins.")
             # Request next agent to reload the configuration
             self.db.reload_configuration(self.plugin_config_version)
             # Reload configuration. Version will be updated during reinitialization,
             # so we don't receive our own request.
             self.__initialize_agent()
-        if task.type == TaskType.SEARCH:
+        elif task.type == TaskType.SEARCH:
             job = JobId(task.data)
             logging.info(f"search: {job.hash}")
 
@@ -272,7 +277,9 @@ class Agent:
         self.__initialize_agent()
 
         while True:
-            task = self.db.agent_get_task(self.group_id, self.plugin_config_version)
+            task = self.db.agent_get_task(
+                self.group_id, self.plugin_config_version
+            )
             self.__process_task(task)
 
 

--- a/src/db.py
+++ b/src/db.py
@@ -199,7 +199,7 @@ class Database:
 
     def agent_get_task(self, agent_id: str, config_version: str) -> AgentTask:
         agent_prefix = f"agent:{agent_id}"
-        # config-reload is notification queue that is set by web to notify
+        # config-reload is a notification queue that is set by web to notify
         # agents that configuration has been changed
         task_queues = [
             f"config-reload:{config_version}",

--- a/src/db.py
+++ b/src/db.py
@@ -12,6 +12,7 @@ from enum import Enum
 class TaskType(Enum):
     SEARCH = "search"
     YARA = "yara"
+    RELOAD = "reload"
 
 
 class AgentTask:
@@ -190,14 +191,26 @@ class Database:
             job=self.get_job(job), matches=[json.loads(m) for m in meta]
         )
 
-    def agent_get_task(self, agent_id: str) -> AgentTask:
+    def reload_configuration(self, config_version: str):
+        # Send request to any of agents that configuration must be reloaded
+        self.redis.rpush(f"config-reload:{config_version}", "reload")
+        # After 300 seconds of inactivity: reload request is deleted
+        self.redis.expire(f"config-reload:{config_version}", 300)
+
+    def agent_get_task(self, agent_id: str, config_version: str) -> AgentTask:
         agent_prefix = f"agent:{agent_id}"
+        # config-reload is notification queue that is set by web to notify
+        # agents that configuration has been changed
         task_queues = [
+            f"config-reload:{config_version}"
             f"{agent_prefix}:queue-search",
             f"{agent_prefix}:queue-yara",
         ]
         queue_task: Any = self.redis.blpop(task_queues)
         queue, task = queue_task
+
+        if queue == f"config-reload:{config_version}":
+            return AgentTask(TaskType.RELOAD, task)
 
         if queue.endswith(":queue-search"):
             return AgentTask(TaskType.SEARCH, task)
@@ -279,7 +292,7 @@ class Database:
         ]
 
     def get_plugin_config_version(self) -> str:
-        return self.redis.get("plugin-version")
+        return self.redis.get("plugin-version") or "initial"
 
     def get_plugin_configuration(self, plugin_name: str) -> Dict[str, str]:
         return self.redis.hgetall(f"plugin:{plugin_name}")
@@ -288,7 +301,8 @@ class Database:
         self, plugin_name: str, key: str, value: str
     ) -> None:
         self.redis.hset(f"plugin:{plugin_name}", key, value)
-        self.redis.set("plugin-version", self.redis.time()[0])
+        prev_version = self.redis.set("plugin-version", self.redis.time()[0]) or "initial"
+        self.reload_configuration(prev_version)
 
     def cache_get(self, key: str, expire: int) -> Optional[str]:
         value = self.redis.get(f"cached:{key}")


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the current behaviour?**
- Agent checks whether configuration has changed during processing of Yara task. In "required plugins" feature (#144) we need to be sure that configuration is guaranteed to be updated by all agents and it will occur after relevant time.

**What is the new behaviour?**

After configuration change: reload task is sent to the `config-reload-{previous_version}` queue. Agent are listening for tasks related to the version they're currently on. When reload task is fetched: agent sends another request to be fetched by another agent and reloads the configuration. 

After 300 seconds of inactivity: mquery assumes that all agents have already abandoned that version and task expires.

**Test plan**

Tested manually:
- initial configuration set on single daemon
- configuration set with 3 agents sharing the same identity (`docker-compose -f docker-compose.dev.yml up --scale dev-daemon=3`)

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

Related with #67 
Dependency of #144 
