### PR TITLE
Show number of errored samples

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -98,21 +98,20 @@ class Agent:
             try:
                 matches = rule.match(sample)
                 if matches:
-                    num_matches += 1
                     self.__update_metadata(
                         job, sample, [r.rule for r in matches]
                     )
+                    num_matches += 1
             except yara.Error:
-                logging.exception(f"Yara failed to check file {sample}")
+                logging.error("Yara failed to check file %s", sample)
                 num_errors += 1
             except FileNotFoundError:
-                logging.exception(
-                    f"Failed to open file for yara check: {sample}"
-                )
+                logging.error("Failed to open file for yara check: %s", sample)
                 num_errors += 1
-        logging.exception(f"Error files: {num_errors}")
 
-        self.db.job_update_error(job, num_errors)
+        if num_errors > 0:
+            self.db.job_update_error(job, num_errors)
+
         self.db.job_update_work(job, len(files), num_matches)
 
     def __yara_task(self, job: JobId, iterator: str) -> None:

--- a/src/db.py
+++ b/src/db.py
@@ -122,7 +122,7 @@ class Database:
         self.redis.hincrby(job.key, "files_matched", files_matched)
 
     def job_update_error(self, job: JobId, files_errored: int) -> None:
-        """ Update error for the job if it appears during agents' work. 
+        """ Update error for the job if it appears during agents' work.
         This will increment number of files errored and write them to the variable.
         """
         self.redis.hincrby(job.key, "files_errored", files_errored)

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -220,7 +220,7 @@ class QueryResultsStatus extends Component {
                 </div>
             );
         }
-
+        console.log(this.props.job.files_error);
         return (
             <div>
                 <div className="progress" style={{ marginTop: "55px" }}>
@@ -257,6 +257,12 @@ class QueryResultsStatus extends Component {
                         >
                             {this.props.job.status}
                         </span>
+                        {this.props.job.total_files - lenMatches > 0 && (
+                            <span style={{ color: "grey", fontSize: "12px" }}>
+                                {" "}
+                                {this.props.job.files_errored} files was missed
+                            </span>
+                        )}
                     </div>
                     <div className="col-md-3">
                         Processed: <span>{processed}</span>

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -153,6 +153,7 @@ class QueryResultsStatus extends Component {
         let errored = Math.round(
             (this.props.job.files_errored / this.props.job.total_files) * 100
         );
+        let errorTooltip = `${this.props.job.files_errored} errors during processing`;
         let cancel = (
             <button
                 className="btn btn-danger btn-sm"
@@ -246,10 +247,10 @@ class QueryResultsStatus extends Component {
                         <div
                             className={"progress-bar bg-danger"}
                             role="progressbar"
-                            style={{ width: errored + "%" }}
-                        >
-                            {errored}%
-                        </div>
+                            style={{ width: Math.max(3, errored) + "%" }}
+                            data-toggle="tooltip"
+                            title={errorTooltip}
+                        />
                     )}
                 </div>
                 <div className="row m-0 pt-3">
@@ -268,12 +269,6 @@ class QueryResultsStatus extends Component {
                         >
                             {this.props.job.status}
                         </span>
-                        {this.props.job.files_errored > 0 && (
-                            <span style={{ color: "grey", fontSize: "12px" }}>
-                                {" "}
-                                {this.props.job.files_errored} files was missed
-                            </span>
-                        )}
                     </div>
                     <div className="col-md-3">
                         Processed: <span>{processed}</span>

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -150,6 +150,9 @@ class QueryResultsStatus extends Component {
         );
         let processed =
             this.props.job.files_processed + " / " + this.props.job.total_files;
+        let errored = Math.round(
+            (this.props.job.files_errored / this.props.job.total_files) * 100
+        );
         let cancel = (
             <button
                 className="btn btn-danger btn-sm"
@@ -220,7 +223,6 @@ class QueryResultsStatus extends Component {
                 </div>
             );
         }
-        console.log(this.props.job.files_error);
         return (
             <div>
                 <div className="progress" style={{ marginTop: "55px" }}>
@@ -240,6 +242,15 @@ class QueryResultsStatus extends Component {
                             {processing}%
                         </div>
                     )}
+                    {this.props.job.files_errored > 0 && (
+                        <div
+                            className={"progress-bar bg-danger"}
+                            role="progressbar"
+                            style={{ width: errored + "%" }}
+                        >
+                            {errored}%
+                        </div>
+                    )}
                 </div>
                 <div className="row m-0 pt-3">
                     <div className="col-md-3">
@@ -257,7 +268,7 @@ class QueryResultsStatus extends Component {
                         >
                             {this.props.job.status}
                         </span>
-                        {this.props.job.total_files - lenMatches > 0 && (
+                        {this.props.job.files_errored > 0 && (
                             <span style={{ color: "grey", fontSize: "12px" }}>
                                 {" "}
                                 {this.props.job.files_errored} files was missed

--- a/src/schema.py
+++ b/src/schema.py
@@ -15,6 +15,7 @@ class JobSchema(BaseModel):
     files_matched: int
     files_in_progress: int
     total_files: int
+    files_errored: int
     iterator: Optional[str]
     taint: Optional[str]
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the current behaviour?**
backend information that the file was not found

**What is the new behaviour?**
Counting number of errored samples using a separate function which in the future may allow it to be placed in more places. Sending this information via redis to the front-end and displaying how many files was missed. The information in the backend still remained.

**Test plan**
index some files and then delete some of them next run some query

**Closing issues**

#101