### PR TITLE
Added missing 'job' reference to metadata

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -138,7 +138,7 @@ class Agent:
     ) -> None:
         """ After finding a match, push it into a database and
         update the related metadata """
-        metadata: Metadata = {}
+        metadata: Metadata = {"job": job.hash}
         for plugin in self.active_plugins:
             try:
                 extracted_meta = plugin.run(file_path, metadata)

--- a/src/plugins/mwdb_uploads.py
+++ b/src/plugins/mwdb_uploads.py
@@ -10,7 +10,7 @@ from metadata import Metadata, MetadataPlugin, MetadataPluginConfig
 
 
 class MalwarecageUploadsMetadata(MetadataPlugin):
-    cacheable = True
+    cacheable = False
     config_fields = {
         "mwdb_url": "URL to the Malwarecage instance (e.g. https://mwdb.cert.pl/)",
         "mwdb_api_url": "API URL to the Malwarecage instance (e.g. https://mwdb.cert.pl/api/)",


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the new behaviour?**
- Job identifier was missing in metadata, so Malwarecage plugin doesn't know the required job id
- Malwarecage plugin should be not cacheable, because job id needs to be assigned for every job.
