### PR TITLE
Incrementing config version instead of using second-resolution timestamp

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -105,7 +105,7 @@ class Agent:
         self.db.agent_continue_search(self.group_id, job_id)
 
     def __load_plugins(self) -> None:
-        self.plugin_config_version = self.db.get_plugin_config_version()
+        self.plugin_config_version: int = self.db.get_plugin_config_version()
         active_plugins = []
         for plugin_class in METADATA_PLUGINS:
             plugin_name = plugin_class.get_name()

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,5 +1,6 @@
 from typing import List, Type
 from metadata import MetadataPlugin
+from .example_plugin import ExampleTagPlugin
 
 # Feel free to import plugins here and add them to list below
-METADATA_PLUGINS: List[Type[MetadataPlugin]] = []
+METADATA_PLUGINS: List[Type[MetadataPlugin]] = [ExampleTagPlugin]

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,6 +1,5 @@
 from typing import List, Type
 from metadata import MetadataPlugin
-from .example_plugin import ExampleTagPlugin
 
 # Feel free to import plugins here and add them to list below
-METADATA_PLUGINS: List[Type[MetadataPlugin]] = [ExampleTagPlugin]
+METADATA_PLUGINS: List[Type[MetadataPlugin]] = []


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the current behaviour?**
- If configuration fields are changed too fast (in single second), configuration version doesn't change twice, but two reload tasks are spawned, so agent reports a bug:

```
Critical error: Requested to reload configuration, but configuration present in database is still the same (<epoch>).
```

**What is the new behaviour?**
- Version is converted to `int` instead of `str` and `INCRBY` is used for getting new version instead of `TIME` with `unix time in seconds` part. Initial value is 0.
