### PR TITLE
Fixed daemon autoreload in dev environment

### DIFF
--- a/deploy/docker/dev.daemon.Dockerfile
+++ b/deploy/docker/dev.daemon.Dockerfile
@@ -9,4 +9,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
 RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
 # ./src is expected to be mounted with a docker volume
-CMD ["./autoreload", "python3 daemon.py"]
+CMD ["./autoreload", "python3", "daemon.py"]

--- a/src/autoreload
+++ b/src/autoreload
@@ -22,7 +22,7 @@ def get_max_mtime():
 
 def run():
     return subprocess.Popen(
-        sys.argv[1], shell=True, stdout=sys.stdout, stderr=sys.stderr
+        sys.argv[1:], stdout=sys.stdout, stderr=sys.stderr
     )
 
 
@@ -33,7 +33,7 @@ def main():
     while True:
         max_mtime, filename = get_max_mtime()
         if max_mtime > last_mtime:
-            print(f"{filename} changed: restarting process.")
+            print(f"{filename} changed: restarting process.", flush=True)
             last_mtime = max_mtime
             process.terminate()
             process.wait()


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the current behaviour?**
- Autoreload script sends SIGTERM to shell which just orphans the daemon without terminating it. Any change in code causes spawning new instances.

**What is the new behaviour?**
- Popen executes Python interpreter directly instead of spawning shell
