### PR TITLE
Remove query from RecentPage

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -225,6 +225,12 @@ def serve_index(path: str) -> FileResponse:
     return FileResponse("mqueryfront/build/index.html")
 
 
+@app.delete("/api/query/{job_id}", response_model=StatusSchema)
+def query_remove(job_id: str) -> StatusSchema:
+    db.remove_query(JobId(job_id))
+    return StatusSchema(status="ok")
+
+
 @app.get("/recent", include_in_schema=False)
 @app.get("/status", include_in_schema=False)
 @app.get("/query", include_in_schema=False)

--- a/src/app.py
+++ b/src/app.py
@@ -175,7 +175,11 @@ def user_jobs(name: str) -> List[JobSchema]:
 
 @app.get("/api/job", response_model=JobsSchema)
 def job_statuses() -> JobsSchema:
-    jobs = [db.get_job(job) for job in db.get_job_ids()]
+    jobs = [
+        db.get_job(job)
+        for job in db.get_job_ids()
+        if db.get_job(job).status != "removed"
+    ]
     jobs = sorted(jobs, key=lambda j: j.submitted, reverse=True)
     return JobsSchema(jobs=jobs)
 

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -184,7 +184,7 @@ class Agent:
         that other agents will be able to work on it in parallel). Later,
         process the obtained files.
         """
-        final_statuses = ["cancelled", "failed", "done"]
+        final_statuses = ["cancelled", "failed", "done", "removed"]
         j = self.db.get_job(job)
         if j.status in final_statuses:
             return

--- a/src/db.py
+++ b/src/db.py
@@ -102,6 +102,10 @@ class Database:
             taint=data.get("taint", None),
         )
 
+    def remove_query(self, job: JobId) -> None:
+        """ Remove query key from redis storage """
+        self.redis.delete(job.key)
+
     def add_match(self, job: JobId, match: MatchInfo) -> None:
         self.redis.rpush(job.meta_key, match.to_json())
 

--- a/src/db.py
+++ b/src/db.py
@@ -103,8 +103,8 @@ class Database:
         )
 
     def remove_query(self, job: JobId) -> None:
-        """ Remove query key from redis storage """
-        self.redis.delete(job.key)
+        """ Sets the job status to removed """
+        self.redis.hmset(job.key, {"status": "removed"})
 
     def add_match(self, job: JobId, match: MatchInfo) -> None:
         self.redis.rpush(job.meta_key, match.to_json())

--- a/src/mqueryfront/src/RecentPage.js
+++ b/src/mqueryfront/src/RecentPage.js
@@ -51,7 +51,9 @@ class RecentPage extends Component {
         if (index >= 0) {
             const newJobs = [...jobs.slice(0, index), ...jobs.slice(index + 1)];
 
-            this.setState({ jobs: newJobs, head: this.getHead(newJobs) });
+            axios.delete(API_URL + "/query/" + id).then((response) => {
+                this.setState({ jobs: newJobs, head: this.getHead(newJobs) });
+            });
         }
     }
 


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the current behaviour?**
Currently pressing the close button removes the query from the RecentPage but not from the redis storage.
After refreshing the site query appears again.

**What is the new behaviour?**
Set the query status to removed and don't send those to the RecentPage.
Query is not removed from the database, it can be further opened under the query link.

**Closing issues**
#143 
