### PR TITLE
Add filter plugins

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -14,7 +14,7 @@ from lib.yaraparse import parse_yara
 
 from util import mquery_version
 from db import Database, JobId
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Union, Dict
 
 from schema import (
     JobsSchema,
@@ -213,7 +213,7 @@ def backend_status() -> BackendStatusSchema:
 
 @app.get("/api/backend/datasets", response_model=BackendStatusDatasetsSchema)
 def backend_status_datasets() -> BackendStatusDatasetsSchema:
-    datasets = {}
+    datasets: Dict[str, int] = {}
     for agent_spec in db.get_active_agents().values():
         try:
             ursa = UrsaDb(agent_spec.ursadb_url)

--- a/src/config.docker.py
+++ b/src/config.docker.py
@@ -6,3 +6,4 @@ REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
 JOB_EXPIRATION_MINUTES = int(
     os.environ.get("JOB_EXPIRATION_MINUTES", 0)
 )  # infinite by default
+PLUGINS = list(filter(None, os.environ.get("MQUERY_PLUGINS", "").split()))

--- a/src/config.docker.py
+++ b/src/config.docker.py
@@ -1,4 +1,5 @@
 import os
+from plugins import parse_plugin_list
 
 BACKEND = os.environ.get("MQUERY_BACKEND", "tcp://ursadb:9281")
 REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
@@ -6,4 +7,4 @@ REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
 JOB_EXPIRATION_MINUTES = int(
     os.environ.get("JOB_EXPIRATION_MINUTES", 0)
 )  # infinite by default
-PLUGINS = list(filter(None, os.environ.get("MQUERY_PLUGINS", "").split()))
+PLUGINS = parse_plugin_list(os.environ.get("MQUERY_PLUGINS", ""))

--- a/src/config.example.py
+++ b/src/config.example.py
@@ -1,5 +1,7 @@
+from typing import List
+
 BACKEND = "tcp://127.0.0.1:9281"
 REDIS_HOST = "127.0.0.1"
 REDIS_PORT = 6379
 JOB_EXPIRATION_MINUTES = 0  # infinite by default
-PLUGINS = []
+PLUGINS: List[str] = []

--- a/src/config.example.py
+++ b/src/config.example.py
@@ -2,3 +2,4 @@ BACKEND = "tcp://127.0.0.1:9281"
 REDIS_HOST = "127.0.0.1"
 REDIS_PORT = 6379
 JOB_EXPIRATION_MINUTES = 0  # infinite by default
+PLUGINS = []

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -13,7 +13,6 @@ from cachetools import cached, LRUCache
 from metadata import MetadataPlugin, Metadata
 from plugins import load_plugins
 
-
 METADATA_PLUGINS = load_plugins(config.PLUGINS)
 
 

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -193,6 +193,9 @@ class Agent:
                 )
                 num_errors += 1
 
+        for plugin in self.active_plugins:
+            plugin.cleanup()
+
         if num_errors > 0:
             self.db.job_update_error(job, num_errors)
 

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -1,5 +1,5 @@
 import json
-from abc import ABC, abstractmethod
+from abc import ABC
 from db import Database
 from typing import Any, Dict, Optional
 
@@ -16,6 +16,10 @@ class MetadataPlugin(ABC):
     cache_expire_time: int = DEFAULT_CACHE_EXPIRE_TIME
     #: Configuration keys required by plugin with description as a value
     config_fields: Dict[str, str] = {}
+    # can this plugin be used for prefiltering mwdb results?
+    is_filter = False
+    # can this plugin be used for extracting metadata?
+    is_extractor = False
 
     def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
         self.db = db
@@ -24,12 +28,6 @@ class MetadataPlugin(ABC):
                 raise KeyError(
                     f"Required configuration key '{key}' is not set"
                 )
-
-        # can this plugin be used for prefiltering mwdb results?
-        self.is_filter = False
-
-        # can this plugin be used for extracting metadata?
-        self.is_extractor = False
 
     @classmethod
     def get_name(cls) -> str:

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -84,12 +84,13 @@ class MetadataPlugin(ABC):
             self._cache_store(identifier, result)
         return result
 
-    def filter(self, matched_fname: str) -> Optional[str]:
+    def filter(self, matched_fname: str, file_path: str) -> Optional[str]:
         """
         Checks if the file is a good candidate for further processing,
         and fix the file path if necessary.
-        :param matched_fname: Matched file path
-        :return: New path to file (may be the same path). None if the file
+        :param matched_fname: Original file path coming from ursadb
+        :param file_path: Current path to the file contents
+        :return: New path to a file (may be the same path). None if the file
         should be discarded.
         """
         raise NotImplementedError

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -94,6 +94,13 @@ class MetadataPlugin(ABC):
         """
         raise NotImplementedError
 
+    def cleanup(self) -> None:
+        """
+        Optionally, clean up after the plugin, for example remove any
+        temporary files. Called after processing a single batch of files.
+        """
+        pass
+
     def extract(
         self, identifier: str, matched_fname: str, current_meta: Metadata
     ) -> Metadata:

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -84,12 +84,13 @@ class MetadataPlugin(ABC):
             self._cache_store(identifier, result)
         return result
 
-    def filter(self, matched_fname: str) -> bool:
+    def filter(self, matched_fname: str) -> Optional[str]:
         """
-        Checks if the file is a good candidate for further processing.
-        False otherwise.
+        Checks if the file is a good candidate for further processing,
+        and fix the file path if necessary.
         :param matched_fname: Matched file path
-        :return: True if the file should be kept. False otherwise.
+        :return: New path to file (may be the same path). None if the file
+        should be discarded.
         """
         raise NotImplementedError
 

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,6 +1,5 @@
 from typing import List, Type
 from metadata import MetadataPlugin
-from .blacklist import RegexBlacklistPlugin
 
 # Feel free to import plugins here and add them to list below
-METADATA_PLUGINS: List[Type[MetadataPlugin]] = [RegexBlacklistPlugin]
+METADATA_PLUGINS: List[Type[MetadataPlugin]] = []

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -3,6 +3,29 @@ from metadata import MetadataPlugin
 from importlib import import_module
 
 
+def parse_plugin_list(plugins: str) -> List[str]:
+    """Parses and validates a plugin list into a list of non-empty components
+    divided by `,`.
+
+    >>> parse_plugin_list("plugins.Test, plugins.Other")
+    ["plugins.Test", "plugins.Other"]
+
+    >>> parse_plugin_list("")
+    []
+
+    :param plugins: String with a list of comma separated plugins
+    :return: List of plugins, with no unnecessary spaces.
+    """
+    result = []
+    for desc in plugins.split(","):
+        desc = desc.strip()
+        if not desc:
+            continue
+        assert ":" in desc
+        result.append(desc)
+    return result
+
+
 def load_plugins(specs: List[str]) -> List[Type[MetadataPlugin]]:
     result = []
     for spec in specs:

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,5 +1,12 @@
 from typing import List, Type
 from metadata import MetadataPlugin
+from importlib import import_module
 
-# Feel free to import plugins here and add them to list below
-METADATA_PLUGINS: List[Type[MetadataPlugin]] = []
+
+def load_plugins(specs: List[str]) -> List[Type[MetadataPlugin]]:
+    result = []
+    for spec in specs:
+        module, classname = spec.split(":")
+        moduleobj = import_module(module)
+        result.append(getattr(moduleobj, classname))
+    return result

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,5 +1,6 @@
 from typing import List, Type
 from metadata import MetadataPlugin
+from .blacklist import RegexBlacklistPlugin
 
 # Feel free to import plugins here and add them to list below
-METADATA_PLUGINS: List[Type[MetadataPlugin]] = []
+METADATA_PLUGINS: List[Type[MetadataPlugin]] = [RegexBlacklistPlugin]

--- a/src/plugins/archive.py
+++ b/src/plugins/archive.py
@@ -1,0 +1,30 @@
+from db import Database
+from metadata import MetadataPlugin, MetadataPluginConfig
+from typing import Optional, List, IO
+import gzip
+import shutil
+import tempfile
+
+
+class GzipPlugin(MetadataPlugin):
+    is_filter = True
+
+    def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
+        super().__init__(db, config)
+        self.tmpfiles: List[IO[bytes]] = []
+
+    def filter(self, orig_name: str, file_path: str) -> Optional[str]:
+        tmp = tempfile.NamedTemporaryFile()
+        self.tmpfiles.append(tmp)
+        if orig_name.endswith(".gz"):
+            with gzip.open(file_path, "rb") as f_in:
+                with open(tmp.name, "wb") as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            return tmp.name
+
+        return file_path
+
+    def clean(self):
+        for tmp in self.tmpfiles:
+            tmp.close()
+        self.tmpfiles = []

--- a/src/plugins/archive.py
+++ b/src/plugins/archive.py
@@ -7,6 +7,11 @@ import tempfile
 
 
 class GzipPlugin(MetadataPlugin):
+    """ Can be used to automatically extract gzip contents before running
+    Yara on them. This plugin will look for all files that end with .gz,
+    and add extract them to disk before further processing.
+    """
+
     is_filter = True
 
     def __init__(self, db: Database, config: MetadataPluginConfig) -> None:

--- a/src/plugins/blacklist.py
+++ b/src/plugins/blacklist.py
@@ -5,6 +5,11 @@ from typing import Optional
 
 
 class RegexBlacklistPlugin(MetadataPlugin):
+    """ Can be used to ignore files with filenames matching a certain
+    pattern. For example, to ignore all pcap files, set blacklist_pattern
+    to "[.]pcap$".
+    """
+
     is_filter = True
     config_fields = {
         "blacklist_pattern": "Regular expression for files that should be ignored",

--- a/src/plugins/blacklist.py
+++ b/src/plugins/blacklist.py
@@ -1,6 +1,7 @@
 import re
 from db import Database
 from metadata import MetadataPlugin, MetadataPluginConfig
+from typing import Optional
 
 
 class RegexBlacklistPlugin(MetadataPlugin):
@@ -13,7 +14,7 @@ class RegexBlacklistPlugin(MetadataPlugin):
         super().__init__(db, config)
         self.blacklist_pattern = config["blacklist_pattern"]
 
-    def filter(self, matched_fname: str) -> bool:
-        if re.search(self.blacklist_pattern, matched_fname,) is not None:
-            return False
-        return True
+    def filter(self, matched_fname: str) -> Optional[str]:
+        if re.search(self.blacklist_pattern, matched_fname):
+            return None
+        return matched_fname

--- a/src/plugins/blacklist.py
+++ b/src/plugins/blacklist.py
@@ -14,7 +14,7 @@ class RegexBlacklistPlugin(MetadataPlugin):
         super().__init__(db, config)
         self.blacklist_pattern = config["blacklist_pattern"]
 
-    def filter(self, matched_fname: str) -> Optional[str]:
-        if re.search(self.blacklist_pattern, matched_fname):
+    def filter(self, orig_name: str, file_path: str) -> Optional[str]:
+        if re.search(self.blacklist_pattern, orig_name):
             return None
-        return matched_fname
+        return file_path

--- a/src/plugins/blacklist.py
+++ b/src/plugins/blacklist.py
@@ -1,0 +1,19 @@
+import re
+from db import Database
+from metadata import MetadataPlugin, MetadataPluginConfig
+
+
+class RegexBlacklistPlugin(MetadataPlugin):
+    config_fields = {
+        "blacklist_pattern": "Regular expression for files that should be ignored",
+    }
+
+    def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
+        super().__init__(db, config)
+        self.blacklist_pattern = config["blacklist_pattern"]
+        self.is_filter = True
+
+    def filter(self, matched_fname: str) -> bool:
+        if re.search(self.blacklist_pattern, matched_fname,) is not None:
+            return False
+        return True

--- a/src/plugins/blacklist.py
+++ b/src/plugins/blacklist.py
@@ -4,6 +4,7 @@ from metadata import MetadataPlugin, MetadataPluginConfig
 
 
 class RegexBlacklistPlugin(MetadataPlugin):
+    is_filter = True
     config_fields = {
         "blacklist_pattern": "Regular expression for files that should be ignored",
     }
@@ -11,7 +12,6 @@ class RegexBlacklistPlugin(MetadataPlugin):
     def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
         super().__init__(db, config)
         self.blacklist_pattern = config["blacklist_pattern"]
-        self.is_filter = True
 
     def filter(self, matched_fname: str) -> bool:
         if re.search(self.blacklist_pattern, matched_fname,) is not None:

--- a/src/plugins/cuckoo_analysis.py
+++ b/src/plugins/cuckoo_analysis.py
@@ -9,12 +9,12 @@ from metadata import Metadata, MetadataPlugin, MetadataPluginConfig
 
 class CuckooAnalysisMetadata(MetadataPlugin):
     cacheable = True
+    is_extractor = True
     config_fields = {"path": "Root of cuckoo analysis directory."}
 
     def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
         super().__init__(db, config)
         self.path = config["path"]
-        self.is_extractor = True
 
     def identify(self, matched_fname: str) -> Optional[str]:
         m = re.search(r"analyses/([0-9]+)/", matched_fname)

--- a/src/plugins/cuckoo_analysis.py
+++ b/src/plugins/cuckoo_analysis.py
@@ -14,6 +14,7 @@ class CuckooAnalysisMetadata(MetadataPlugin):
     def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
         super().__init__(db, config)
         self.path = config["path"]
+        self.is_extractor = True
 
     def identify(self, matched_fname: str) -> Optional[str]:
         m = re.search(r"analyses/([0-9]+)/", matched_fname)

--- a/src/plugins/cuckoo_binaries.py
+++ b/src/plugins/cuckoo_binaries.py
@@ -2,16 +2,11 @@ import re
 
 from typing import Optional
 
-from db import Database
-from metadata import Metadata, MetadataPlugin, MetadataPluginConfig
+from metadata import Metadata, MetadataPlugin
 
 
 class CuckooBinariesMetadata(MetadataPlugin):
-    cacheable = False
-
-    def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
-        super().__init__(db, config)
-        self.is_extractor = True
+    is_extractor = True
 
     def identify(self, matched_fname: str) -> Optional[str]:
         m = re.search(r"/binaries/([a-f0-9]+)$", matched_fname)

--- a/src/plugins/cuckoo_binaries.py
+++ b/src/plugins/cuckoo_binaries.py
@@ -2,11 +2,16 @@ import re
 
 from typing import Optional
 
-from metadata import Metadata, MetadataPlugin
+from db import Database
+from metadata import Metadata, MetadataPlugin, MetadataPluginConfig
 
 
 class CuckooBinariesMetadata(MetadataPlugin):
     cacheable = False
+
+    def __init__(self, db: Database, config: MetadataPluginConfig) -> None:
+        super().__init__(db, config)
+        self.is_extractor = True
 
     def identify(self, matched_fname: str) -> Optional[str]:
         m = re.search(r"/binaries/([a-f0-9]+)$", matched_fname)

--- a/src/plugins/example_plugin.py
+++ b/src/plugins/example_plugin.py
@@ -5,6 +5,7 @@ from metadata import Metadata, MetadataPlugin, MetadataPluginConfig
 
 class ExampleTagPlugin(MetadataPlugin):
     cacheable = True
+    is_extractor = True
     config_fields = {
         "tag": "Everything will be tagged using that tag",
         "tag_url": "Tag URL e.g. http://google.com?q={tag}",
@@ -14,7 +15,6 @@ class ExampleTagPlugin(MetadataPlugin):
         super().__init__(db, config)
         self.tag = config["tag"]
         self.tag_url = config["tag_url"]
-        self.is_extractor = True
 
     def extract(
         self, identifier: str, matched_fname: str, current_meta: Metadata

--- a/src/plugins/example_plugin.py
+++ b/src/plugins/example_plugin.py
@@ -14,6 +14,7 @@ class ExampleTagPlugin(MetadataPlugin):
         super().__init__(db, config)
         self.tag = config["tag"]
         self.tag_url = config["tag_url"]
+        self.is_extractor = True
 
     def extract(
         self, identifier: str, matched_fname: str, current_meta: Metadata

--- a/src/plugins/mwdb_uploads.py
+++ b/src/plugins/mwdb_uploads.py
@@ -11,6 +11,7 @@ from metadata import Metadata, MetadataPlugin, MetadataPluginConfig
 
 class MalwarecageUploadsMetadata(MetadataPlugin):
     cacheable = False
+    is_extractor = True
     config_fields = {
         "mwdb_url": "URL to the Malwarecage instance (e.g. https://mwdb.cert.pl/)",
         "mwdb_api_url": "API URL to the Malwarecage instance (e.g. https://mwdb.cert.pl/api/)",
@@ -23,7 +24,6 @@ class MalwarecageUploadsMetadata(MetadataPlugin):
             api_url=config["mwdb_api_url"], api_key=config["mwdb_api_token"]
         )
         self.mwdb_url = config["mwdb_url"]
-        self.is_extractor = True
 
     def identify(self, matched_fname: str) -> Optional[str]:
         m = re.search(

--- a/src/plugins/mwdb_uploads.py
+++ b/src/plugins/mwdb_uploads.py
@@ -23,6 +23,7 @@ class MalwarecageUploadsMetadata(MetadataPlugin):
             api_url=config["mwdb_api_url"], api_key=config["mwdb_api_token"]
         )
         self.mwdb_url = config["mwdb_url"]
+        self.is_extractor = True
 
     def identify(self, matched_fname: str) -> Optional[str]:
         m = re.search(

--- a/src/util.py
+++ b/src/util.py
@@ -1,5 +1,6 @@
 import logging
 import hashlib
+from typing import Dict, Any
 
 
 LOG_FORMAT = "[%(asctime)s][%(levelname)s] %(message)s"
@@ -12,15 +13,13 @@ def setup_logging() -> None:
     )
 
 
-def mquery_version():
+def mquery_version() -> str:
     return "1.1.0"
 
 
-def update_sha(filename):
+def make_sha256_tag(filename: str) -> Dict[str, Any]:
     sha256_hash = hashlib.sha256()
     with open(filename, "rb") as f:
         for byte_block in iter(lambda: f.read(4096), b""):
             sha256_hash.update(byte_block)
-    return {
-        "sha256": {"display_text": sha256_hash.hexdigest(), "hidden": True}
-    }
+    return {"display_text": sha256_hash.hexdigest(), "hidden": True}


### PR DESCRIPTION
It's currently not easily possible to remove files from mquery. As a
workaround, users can create their own blacklists for files that
should be ignored (for example, using a list of files that
should be ignored, or regular expression for file types that are
not interesting).

This also potentially allows us to query some database to check for
additional constraints on files (for example, cross check with mwdb).

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [soon] I've updated documentation to reflect my change (if applicable) 

**What is the current behaviour?**
No way to prefilter ursadb results

**What is the new behaviour?**
Added code for prefiltering, and example plugin

**Test plan**
- Index some files
- Add a simple blacklist regex in the config, for example "^0" - this should exclude all files that start with 0
- Ensure that no files that start with 0 are in the result

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

