### PR TITLE
remove button as trash-alt black icon, cancel button unified

### DIFF
--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -5,6 +5,7 @@ import Pagination from "react-js-pagination";
 import QueryTimer from "./QueryTimer";
 import { finishedStatuses } from "./QueryUtils";
 import { CopyToClipboard } from "react-copy-to-clipboard";
+import ActionCancel from "./components/ActionCancel";
 
 function MatchItem(props) {
     const metadata = Object.values(props.meta)
@@ -172,14 +173,7 @@ class QueryResultsStatus extends Component {
             (this.props.job.files_errored / this.props.job.total_files) * 100
         );
         let errorTooltip = `${this.props.job.files_errored} errors during processing`;
-        let cancel = (
-            <button
-                className="btn btn-danger btn-sm"
-                onClick={this.handleCancelJob}
-            >
-                cancel
-            </button>
-        );
+        let cancel = <ActionCancel onClick={this.handleCancelJob} size="lg" />;
 
         if (!this.props.job.total_files && this.props.job.status !== "done") {
             progress = 0;

--- a/src/mqueryfront/src/RecentPage.js
+++ b/src/mqueryfront/src/RecentPage.js
@@ -18,7 +18,7 @@ class RecentPage extends Component {
         };
 
         this.handleCancelJob = this.handleCancelJob.bind(this);
-        this.handleClose = this.handleClose.bind(this);
+        this.handleRemove = this.handleRemove.bind(this);
         this.handleFilter = this.handleFilter.bind(this);
         this.getHead = this.getHead.bind(this);
         this.getDistinctList = this.getDistinctList.bind(this);
@@ -44,7 +44,7 @@ class RecentPage extends Component {
         }
     }
 
-    handleClose(id) {
+    handleRemove(id) {
         const { jobs } = this.state;
         const index = jobs.findIndex((obj) => obj.id === id);
 
@@ -170,7 +170,7 @@ class RecentPage extends Component {
                     filter={filter}
                     head={head}
                     onFilter={this.handleFilter}
-                    onClose={this.handleClose}
+                    onRemove={this.handleRemove}
                     onCancel={this.handleCancelJob}
                     activePage={activePage}
                     itemsPerPage={itemsPerPage}

--- a/src/mqueryfront/src/SearchJobs.js
+++ b/src/mqueryfront/src/SearchJobs.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import PriorityIcon from "./components/PriorityIcon";
-import ActionClose from "./components/ActionClose";
+import ActionRemove from "./components/ActionRemove";
 import ActionCancel from "./components/ActionCancel";
 import StatusProgress from "./components/StatusProgress";
 import FilteringTableHeader from "./components/FilteringTableHeader";
@@ -44,12 +44,12 @@ const SearchJobRow = (props) => {
     const rule_author = props.job.rule_author
         ? props.job.rule_author
         : "(no author)";
-    const { onClose, onCancel } = props;
+    const { onRemove, onCancel } = props;
 
     const submittedDate = new Date(submitted * 1000).toISOString();
 
     const actionBtn = finishedStatuses.includes(status) ? (
-        <ActionClose onClick={onClose} />
+        <ActionRemove onClick={onRemove} />
     ) : (
         <ActionCancel onClick={onCancel} />
     );
@@ -98,7 +98,7 @@ const SearchJobs = (props) => {
         head,
         filter,
         onCancel,
-        onClose,
+        onRemove,
         onFilter,
         activePage,
         itemsPerPage,
@@ -112,7 +112,7 @@ const SearchJobs = (props) => {
         <SearchJobRow
             key={job.id}
             job={job}
-            onClose={() => onClose(job.id)}
+            onRemove={() => onRemove(job.id)}
             onCancel={() => onCancel(job.id)}
         />
     ));
@@ -167,7 +167,7 @@ SearchJobs.propTypes = {
     ).isRequired,
     filterValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     onFilter: PropTypes.func.isRequired,
-    onClose: PropTypes.func.isRequired,
+    onRemove: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
 };
 

--- a/src/mqueryfront/src/components/ActionRemove.js
+++ b/src/mqueryfront/src/components/ActionRemove.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import PropTypes from "prop-types";
+
+const ActionRemove = (props) => {
+    return (
+        <button className="btn shadow-none" onClick={props.onClick}>
+            <span data-toggle="tooltip" title={props.tooltipMessage}>
+                <FontAwesomeIcon
+                    icon={faTrashAlt}
+                    size={props.size}
+                    color={props.color}
+                />
+            </span>
+        </button>
+    );
+};
+
+ActionRemove.defaultProps = {
+    size: "1x",
+    tooltipMessage: "remove",
+    color: "black",
+};
+
+ActionRemove.propTypes = {
+    onClick: PropTypes.func.isRequired,
+    size: PropTypes.oneOf([
+        "lg",
+        "xs",
+        "sm",
+        "1x",
+        "2x",
+        "3x",
+        "4x",
+        "5x",
+        "6x",
+        "7x",
+        "8x",
+        "9x",
+        "10x",
+    ]),
+    tooltipMessage: PropTypes.string,
+    color: PropTypes.string,
+};
+
+export default ActionRemove;


### PR DESCRIPTION

![Screenshot from 2020-05-12 13-14-26](https://user-images.githubusercontent.com/63407380/81679608-a124e400-9452-11ea-8ec5-e38c6597b1a4.png)
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [ x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
![CancelQuery](https://user-images.githubusercontent.com/63407380/81679902-db8e8100-9452-11ea-8271-308f715d8036.gif)

Visual changes: 

- changed from close (icon times) to remove (icon trash-alt).

- unified view of cancel button (on query page, from badge to "stop" icon).
