### PR TITLE
Small formatting for the results table

### DIFF
--- a/src/mqueryfront/src/App.css
+++ b/src/mqueryfront/src/App.css
@@ -10,6 +10,23 @@
 
 .mquery-scroll-matches td {
     word-break: break-all;
+    font-family: "monospace"
+}
+
+.mquery-scroll-matches td i {
+    visibility: hidden;
+}
+
+.mquery-scroll-matches td:hover i {
+    visibility: visible;
+}
+
+.mquery-scroll-matches td i:hover {
+    color: var(--blue);
+}
+
+.hash-item {
+    cursor: pointer;
 }
 
 .is-collapsed {

--- a/src/mqueryfront/src/App.css
+++ b/src/mqueryfront/src/App.css
@@ -25,7 +25,7 @@
     color: var(--blue);
 }
 
-.hash-item {
+.copyable-item {
     cursor: pointer;
 }
 

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -8,6 +8,17 @@ import { CopyToClipboard } from "react-copy-to-clipboard";
 import ActionCancel from "./components/ActionCancel";
 
 function MatchItem(props) {
+    const download_url =
+        API_URL +
+        "/download?job_id=" +
+        encodeURIComponent(props.qhash) +
+        "&ordinal=" +
+        encodeURIComponent(props.ordinal) +
+        "&file_path=" +
+        encodeURIComponent(props.file);
+
+    const path = require("path");
+
     const metadata = Object.values(props.meta)
         .filter((v) => !v.hidden)
         .map((v) => (
@@ -17,20 +28,6 @@ function MatchItem(props) {
                     {v.display_text}
                 </span>
             </a>
-        ));
-
-    let hashes = Object.values(props.meta)
-        .filter((v) => v.hidden)
-        .map((v) => (
-            <CopyToClipboard text={v.display_text} key={v}>
-                <div
-                    style={{ fontFamily: "monospace" }}
-                    data-toggle="tooltip"
-                    title="Click to copy"
-                >
-                    {v.display_text}
-                </div>
-            </CopyToClipboard>
         ));
 
     let matches = <span></span>;
@@ -44,35 +41,53 @@ function MatchItem(props) {
         ));
     }
 
-    const download_url =
-        API_URL +
-        "/download?job_id=" +
-        encodeURIComponent(props.qhash) +
-        "&ordinal=" +
-        encodeURIComponent(props.ordinal) +
-        "&file_path=" +
-        encodeURIComponent(props.file);
-
-    const path = require("path");
-
     return (
         <tr>
             <td>
                 <div className="row m-0 text-truncate">
                     <div className="text-truncate" style={{ minWidth: 50 }}>
-                        <a
-                            href={download_url}
-                            data-toggle="tooltip"
-                            title={props.file}
-                        >
+                        <div>
+                            {props.meta.sha256.display_text}
+                            <small>
+                                <a
+                                    href={download_url}
+                                    data-toggle="tooltip"
+                                    title={props.file}
+                                    className="text-secondary"
+                                >
+                                    <i className="fa fa-download fa-xm ml-2" />
+                                </a>
+                                <CopyToClipboard
+                                    text={props.meta.sha256.display_text}
+                                >
+                                    <span
+                                        data-toggle="tooltip"
+                                        title="Copy sha256 to clipboard"
+                                        className="hash-item"
+                                    >
+                                        <i className="fa fa-copy fa-xm ml-2" />
+                                    </span>
+                                </CopyToClipboard>
+                            </small>
+                        </div>
+                        <small class="text-secondary">
                             {path.basename(props.file)}
-                        </a>
+                            <CopyToClipboard text={path.basename(props.file)}>
+                                <span
+                                    data-toggle="tooltip"
+                                    title="Copy file name to clipboard"
+                                    className="hash-item"
+                                >
+                                    <i className="fa fa-copy fa-xm ml-2" />
+                                </span>
+                            </CopyToClipboard>
+                        </small>
+                        {matches}
                     </div>
-                    {matches}
                     {metadata}
+                    <br />
                 </div>
             </td>
-            {props.collapsed ? <td>{hashes}</td> : null}
         </tr>
     );
 }
@@ -219,11 +234,6 @@ class QueryResultsStatus extends Component {
                         <thead>
                             <tr>
                                 <th className="col-md-8">Matches</th>
-                                {this.props.collapsed && (
-                                    <th className="col-md-4 d-none d-sm-table-cell">
-                                        SHA256
-                                    </th>
-                                )}
                             </tr>
                         </thead>
                         <tbody>{matches}</tbody>

--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -59,11 +59,11 @@ function MatchItem(props) {
                                 </a>
                                 <CopyToClipboard
                                     text={props.meta.sha256.display_text}
+                                    className="copyable-item"
                                 >
                                     <span
                                         data-toggle="tooltip"
                                         title="Copy sha256 to clipboard"
-                                        className="hash-item"
                                     >
                                         <i className="fa fa-copy fa-xm ml-2" />
                                     </span>
@@ -72,20 +72,21 @@ function MatchItem(props) {
                         </div>
                         <small class="text-secondary">
                             {path.basename(props.file)}
-                            <CopyToClipboard text={path.basename(props.file)}>
+                            <CopyToClipboard
+                                text={path.basename(props.file)}
+                                className="copyable-item"
+                            >
                                 <span
                                     data-toggle="tooltip"
                                     title="Copy file name to clipboard"
-                                    className="hash-item"
                                 >
                                     <i className="fa fa-copy fa-xm ml-2" />
                                 </span>
                             </CopyToClipboard>
                         </small>
                         {matches}
+                        {metadata}
                     </div>
-                    {metadata}
-                    <br />
                 </div>
             </td>
         </tr>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the current behaviour?**
Currently, the results table contains two columns, one for hashes and the other for sha256.
When clicking on the hash in a cell, the hash will be copied to the clipboard
![image](https://user-images.githubusercontent.com/20182642/81845931-f861ac00-9559-11ea-9f27-b17e791de931.png)

**What is the new behaviour?**
Since we enjoy tons of space on this table, and because we plan to add more info (file size, mwdb data, ...) I thought of making a few cosmetic changes.

Changes made:
- One column to contain everything nicely
- I believe that the sha256 is more important for the user than the internal filename, so I made it the main item in the
- A copy icon for both file name and hashes, visible on cell hover
- A download icon, visible on cell hover

![image](https://user-images.githubusercontent.com/20182642/81846129-4a0a3680-955a-11ea-9b72-4445e7649d8e.png)


![Peek 2020-05-13 20-43](https://user-images.githubusercontent.com/20182642/81846247-6f974000-955a-11ea-9185-df4216901cd1.gif)


**Test plan**
 - Check that hashes are copied correctly
 - Check that filenames are copied correctly
 - Check that download works correctly
 - Check files with loooooong file names (can use the browser's developers-tools for this)


