### PR TITLE
Add a CLI tool to download and/or query mquery

### DIFF
--- a/src/utils/download.py
+++ b/src/utils/download.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python3
+
+import argparse
+import time
+import requests
+import os
+
+
+class OutputSettings:
+    def __init__(self):
+        self.print_hash = True
+        self.print_matches = False
+        self.print_filenames = False
+        self.save_to_directory = None
+
+
+def query(mquery_server: str, yara_rule: str) -> str:
+    """ Queries mquery server and returns a new job ID """
+    res = requests.post(
+        f"{mquery_server}/api/query",
+        json={
+            "method": "query",
+            "raw_yara": yara_rule,
+            "taint": None,
+            "priority": "normal",
+            "method": "query",
+        },
+    ).json()
+    if "error" in res:
+        raise RuntimeError("Query error: " + res["error"])
+
+    return res["query_hash"]
+
+
+def process_job(
+    mquery_server: str, job_id: str, output: OutputSettings
+) -> None:
+    offset = 0
+
+    while True:
+        MAX_SAMPLES = 50
+        out = requests.get(
+            f"{mquery_server}/api/matches/{job_id}",
+            {"offset": offset, "limit": MAX_SAMPLES},
+        ).json()
+
+        if "error" in out:
+            raise RuntimeError(out["error"])
+
+        matches = out["matches"]
+        for match in matches:
+            sha256 = match["meta"]["sha256"]["display_text"]
+            line = sha256
+
+            file_path = match["file"]
+            if output.print_filenames:
+                line += f" {file_path}"
+
+            if output.print_matches:
+                for matched_rule in match["matches"]:
+                    line += f" {matched_rule}"
+
+            print(line)
+
+            if output.save_to_directory is not None:
+                with open(
+                    f"{output.save_to_directory}/{sha256}", "wb"
+                ) as outf:
+                    r = requests.get(
+                        f"{mquery_server}/api/download",
+                        {
+                            "job_id": job_id,
+                            "ordinal": offset,
+                            "file_path": file_path,
+                        },
+                    )
+                    outf.write(r.content)
+
+            offset += 1
+
+        FINISHED_STATES = ["cancelled", "failed", "done", "removed"]
+        if not matches and out["job"]["status"] in FINISHED_STATES:
+            break
+
+        if len(matches) < MAX_SAMPLES:
+            time.sleep(1.0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--yara", help="Yara rule to use for query")
+    group.add_argument("--job", help="Job ID to print or download")
+
+    parser.add_argument(
+        "--mquery",
+        default="http://localhost",
+        help="Change mquery server address",
+    )
+    parser.add_argument(
+        "--print-filenames",
+        default=False,
+        action="store_true",
+        help="Also print filenames",
+    )
+    parser.add_argument(
+        "--print-matches",
+        default=False,
+        action="store_true",
+        help="Also print matched rules",
+    )
+    parser.add_argument(
+        "--save",
+        default=None,
+        help="Download samples and save to the provided directory",
+    )
+
+    args = parser.parse_args()
+    output = OutputSettings()
+    output.print_filenames = args.print_filenames
+    output.print_matches = args.print_matches
+    output.save_to_directory = args.save
+
+    if args.save is not None:
+        os.makedirs(args.save, exist_ok=True)
+
+    if args.yara:
+        with open(args.yara, "r") as f:
+            yara_rule = f.read()
+        job_id = query(args.mquery, yara_rule)
+    else:
+        job_id = args.job
+
+    process_job(args.mquery, job_id, output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/mquery.py
+++ b/src/utils/mquery.py
@@ -79,10 +79,10 @@ def process_job(
             offset += 1
 
         FINISHED_STATES = ["cancelled", "failed", "done", "removed"]
-        if not matches and out["job"]["status"] in FINISHED_STATES:
-            break
+        if not matches:
+            if out["job"]["status"] in FINISHED_STATES:
+                break
 
-        if len(matches) < MAX_SAMPLES:
             time.sleep(1.0)
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [n/a] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [n/a] I've added automated tests for my change (if applicable, optional)
- [in other PR] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
There is no `download` script that can be used to download files from mquery. Or rather, there are two:
 - one in random repository in cert.pl
 - one was removed from this repo long time ago

**What is the new behaviour?**
download script!

**Test plan**
1. Create a file `rule.yar` with a simple yara rule.
2. Run
```
python3 query.py --yara rule.yar --print-matches --print-filename --save kot
```

Expected result - something like:
```
$ python3 download.py --yara rule.yar --print-matches --print-filename --save kot
89b27295b3ed353e38ab67c1d21d44578461413249d28d960f1c6fb4195dbb1b /mnt/samples/exception1 test
dacdab7b47f0788b20d33a44500cd3396d47894f37e32d0bd54aa2dbb4e5eed0 /mnt/samples/exception2 test
387e6f8912fb8ded6bca4d16c464bc186ad03759529b7ba8b19a54b590c13ab1 /mnt/samples/kot/mquery/README.md test
98b7b3faab88ff62720af747195156a3694131aa2fd760753ff48b044da310d4 /mnt/samples/kot/mquery/src/app.py test
fcc7183658c7a6f92a580e3ea4ee8f3987b58a4fec08a0a826f5aee2226cda53 /mnt/samples/kot/mquery/src/daemon.py test
ed04594b5bae61d40b8da8c81d9a0cf1b4aba44144f06cca674e0ea98d691dd5 /mnt/samples/kot/mquery/src/lib/yaraparse.py test
442e658f0adaf384170cddc735d86cb3d5d6f5a6932af77d4080a88551790b53 /mnt/samples/kot/mquery/src/lib/__pycache__/yaraparse.cpython-37.pyc test
b2695a80ce56561577ee5b7f31f4b3119782e4b45fad599b33c153acf202a129 /mnt/samples/kot/mquery/src/tests/test_api.py test
0abae63ce933d3f458cd710302a800a87b67bb643a5917098ec97a820dd7232f /mnt/samples/kot/mquery/src/tests/__pycache__/test_api.cpython-37-pytest-5.4.1.pyc test
4cfda945446db1d2d65fcce3de5322c679ce1b26c3205fb76f2d05ed19d86bf5 /mnt/samples/kot/mquery/src/__pycache__/app.cpython-37.pyc test

```

