### PR TITLE
Fix overlooked grammar comments by Megabeets

### DIFF
--- a/src/utils/mquery.py
+++ b/src/utils/mquery.py
@@ -102,18 +102,18 @@ def main():
         "--print-filenames",
         default=False,
         action="store_true",
-        help="Also print filenames",
+        help="Print matched filenames",
     )
     parser.add_argument(
         "--print-matches",
         default=False,
         action="store_true",
-        help="Also print matched rules",
+        help="Print matched rules",
     )
     parser.add_argument(
         "--save",
         default=None,
-        help="Download samples and save to the provided directory",
+        help="Download matched samples to the provided directory",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [n/a] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [n/a] I've added automated tests for my change (if applicable, optional)
- [n/a] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
There are grammar mistakes in the `mquery.py` script. I've missed the comments from @ITAYC0HEN on the previous PR (or rather, I've added them to batch and forgot to commit).

**What is the new behaviour?**
Three grammar mistakes less, 1334 more to go.

**Test plan**
Step 1: Learn English.
Step 2: Ensure that the changed sentences are now grammaticaly correct


