### PR TITLE
Compatibility fix for old jobs without sha256 meta tag

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -204,9 +204,15 @@ class Database:
         else:
             end = offset + limit - 1
         meta = self.redis.lrange("meta:" + job.hash, offset, end)
-        return MatchesSchema(
-            job=self.get_job(job), matches=[json.loads(m) for m in meta]
-        )
+        matches = [json.loads(m) for m in meta]
+        for match in matches:
+            # Compatibility fix for old jobs, without sha256 metadata key.
+            if "sha256" not in match["meta"]:
+                match["meta"]["sha256"] = {
+                    "display_text": "0" * 64,
+                    "hidden": True,
+                }
+        return MatchesSchema(job=self.get_job(job), matches=matches)
 
     def reload_configuration(self, config_version: int):
         # Send request to any of agents that configuration must be reloaded


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [n/a] I've added automated tests for my change (if applicable, optional)
- [n/a - bugfix] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Results for old jobs don't have sha256 metadata tag. This causes a fatal error on the query page (blank page).

**What is the new behaviour?**
Old jobs will display a default sha256 hash (all zeroes)

**Test plan**
Update old mquery instance, observe that query page doesn't load

