### PR TITLE
Show query time after the query is done

### DIFF
--- a/src/mqueryfront/src/QueryTimer.js
+++ b/src/mqueryfront/src/QueryTimer.js
@@ -37,8 +37,13 @@ class QueryTimer extends Component {
     }
 
     render() {
-        if (!this.props.job.submitted || this.props.isFinished) {
+        if (!this.props.job.submitted) {
             return null;
+        }
+
+        if (this.props.isFinished) {
+            const duration = this.props.job.finished - this.props.job.submitted;
+            return <i>took {this.getRenderTime(duration)}</i>;
         }
 
         let durationSec;

--- a/src/mqueryfront/src/QueryTimer.js
+++ b/src/mqueryfront/src/QueryTimer.js
@@ -43,7 +43,7 @@ class QueryTimer extends Component {
 
         if (this.props.isFinished) {
             const duration = this.props.job.finished - this.props.job.submitted;
-            return <i>took {this.getRenderTime(duration)}</i>;
+            return <i>Duration: {this.getRenderTime(duration)}</i>;
         }
 
         let durationSec;

--- a/src/schema.py
+++ b/src/schema.py
@@ -10,6 +10,7 @@ class JobSchema(BaseModel):
     rule_author: Optional[str]
     raw_yara: str
     submitted: int
+    finished: Optional[int]
     priority: str
     files_processed: int
     files_matched: int


### PR DESCRIPTION
Right now it's not possible to check how long the query took,
and it's a pretty interesting information (at least for me, the developer).

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [yes they are and no i didn't] I've added automated tests for my change (if applicable, optional)
- [-] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Information when the query was finished is not saved and shown anywhere

**What is the new behaviour?**

That small "took 19s" in the lower right corner under the progress bar

![ss](https://user-images.githubusercontent.com/7026881/82100549-2d146580-970a-11ea-98b0-5e27654c0879.png)

**Test plan**
Run a query, ensure that `took XXXs` text is shown after the query is done (also when it's cancelled or it errors out).

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
