### PR TITLE
Fix race condition for queries on the last dataset

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -105,6 +105,7 @@ class Agent:
         self.db.update_job_files(job_id, file_count)
         self.db.agent_start_job(self.group_id, job_id, iterator)
         self.db.agent_continue_search(self.group_id, job_id)
+        self.db.dataset_query_done(job_id)
 
     def __load_plugins(self) -> None:
         self.plugin_config_version: int = self.db.get_plugin_config_version()
@@ -262,7 +263,7 @@ class Agent:
         if (
             j.status == "processing"
             and j.files_processed == j.total_files
-            and self.db.job_datasets_left(self.group_id, job) == 0
+            and j.datasets_to_query == 0
         ):
             # The job is over, work of this agent as done.
             self.db.agent_finish_job(job)

--- a/src/db.py
+++ b/src/db.py
@@ -195,6 +195,9 @@ class Database:
     ) -> Optional[str]:
         return self.redis.lpop(f"job-ds:{agent_id}:{job.hash}")
 
+    def dataset_query_done(self, job: JobId):
+        self.redis.hincrby(job.key, "datasets_to_query", -1)
+
     def job_datasets_left(self, agent_id: str, job: JobId) -> int:
         return self.redis.llen(f"job-ds:{agent_id}:{job.hash}")
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Query can get stuck on the last dataset (so not all files are processed)

**What is the new behaviour?**
The not-so-sneaky race condition was here:

```
dataset = self.db.get_next_search_dataset(self.group_id, job_id)
if dataset is None:
	logging.info("Nothing to query, returning...")
	return

...

self.db.update_job_files(job_id, file_count)
```

`get_next_search_dataset` decrements the number of datasets left
(potentially to zero), and increments number of files to be processed
later. So if ursadb is slower than running yara on the results,
there is a time window where the job appears to be done (all files
processed, no datasets left ot query) when in fact the last dataset
is still being queried.

**Test plan**
Run a complicated query with a good recall. Reproducing it is hard on my local machine, though it's 100% reproducible on my server with a lot of files.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

