### PR TITLE
Count datasets left to query

### DIFF
--- a/src/mqueryfront/src/QueryResultsStatus.js
+++ b/src/mqueryfront/src/QueryResultsStatus.js
@@ -153,6 +153,7 @@ class QueryResultsStatus extends Component {
             files_in_progress,
             files_errored,
             files_matched,
+            datasets_to_query,
         } = job;
 
         if (job && job.error) {
@@ -287,6 +288,15 @@ class QueryResultsStatus extends Component {
                 </div>
             );
         }
+        const toQueryBadge = datasets_to_query ? (
+            <span
+                className="badge badge-pill badge-primary"
+                data-toggle="tooltip"
+                title={datasets_to_query + " datasets left to query"}
+            >
+                {datasets_to_query}
+            </span>
+        ) : null;
         return (
             <div>
                 <div className="progress" style={{ marginTop: "55px" }}>
@@ -327,7 +337,10 @@ class QueryResultsStatus extends Component {
                         <span className={getBadgeClass(status)}>{status}</span>
                     </div>
                     <div className="col-md-3">
-                        Processed: <span>{processed}</span>
+                        Processed:{" "}
+                        <span>
+                            {processed} {toQueryBadge}
+                        </span>
                     </div>
                     <div className="col-md-3" style={{ textAlign: "right" }}>
                         <QueryTimer

--- a/src/schema.py
+++ b/src/schema.py
@@ -18,6 +18,7 @@ class JobSchema(BaseModel):
     files_errored: int
     iterator: Optional[str]
     taint: Optional[str]
+    datasets_to_query: int
 
 
 class JobsSchema(BaseModel):


### PR DESCRIPTION
Sometimes queries take a long time - this makes progressbar
a bit useless. Try to explain why to the user with this small change.

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**

Because of the fact that yara results are streamed now, when the number of yara matches is low it's possible to see things like `processing 17/17`.

**What is the new behaviour?**

There is a small badge next to the counter - numbre of datasets left to query:

![ss](https://user-images.githubusercontent.com/7026881/82149007-05321880-9856-11ea-8849-e36e1ace754b.png)

With tooltip, the best thing since sliced bread:

![ss](https://user-images.githubusercontent.com/7026881/82149010-0d8a5380-9856-11ea-9296-18e0c31c08aa.png)


**Other things that I've considered**

Instead of having this badge, show this on the progress bar with some advanced (fourth grade) math. For example if only half of the (files in) datasets were queried, scale the progressbar to half width and fill the rest with `gray` colour.  

**Test plan**

Run a query and ensure that it still works.
Ensure that the number of datasets to query only decreases, and disappears when it reaches zero 

