### PR TITLE
Auto-restart services on crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   web:
+    restart: always
     build:
       context: .
       dockerfile: deploy/docker/web.Dockerfile
@@ -14,6 +15,7 @@ services:
       - "redis"
       - "ursadb"
   daemon:
+    restart: always
     build:
       context: .
       dockerfile: deploy/docker/daemon.Dockerfile
@@ -26,6 +28,7 @@ services:
       - "redis"
       - "ursadb"
   ursadb:
+    restart: always
     build:
       context: ursadb/
       dockerfile: Dockerfile
@@ -35,4 +38,5 @@ services:
     - "${SAMPLES_DIR}:/mnt/samples"
     - "${INDEX_DIR}:/var/lib/ursadb"
   redis:
+    restart: always
     image: redis


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Right now, when one of the services crashes (and by `one of the services` i
mean ursadb running OOM when there are too many workers) it's not started
again, and the user has to restart it manually.

Of course services crashing is a pretty bad thing (and should not happen),
but having a database lose a single task and restart is still better than
user having to restart it manually.

This is only relevant to docker-compose deployments.

**What is the new behaviour?**
Assuming docker-compose does its job, service should restart automatically.

**Test plan**
- Start mquery normally.
- `config set "database_workers" 1023` with ursacli;
- Run multiple indexing jobs at the same time
- Observe the results

