### PR TITLE
Don't show removed jobs in the UI

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -192,6 +192,7 @@ def job_statuses() -> JobsSchema:
     """
     jobs = [db.get_job(job) for job in db.get_job_ids()]
     jobs = sorted(jobs, key=lambda j: j.submitted, reverse=True)
+    jobs = [j for j in jobs if j.status != "removed"]
     return JobsSchema(jobs=jobs)
 
 


### PR DESCRIPTION
Backport a fix for removed jobs, which either somehow slipped
through the review, or was introduced later - removed jobs
are still shown in the recents job list because they're not filtered.

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Remove a job:

![ss](https://user-images.githubusercontent.com/7026881/82150975-5d6b1980-985a-11ea-86b5-ca58d784f316.png)

Press F5

![ss](https://user-images.githubusercontent.com/7026881/82150993-71af1680-985a-11ea-90b9-fb2e41bb71cb.png)

**What is the new behaviour?**

Remove a job:

![ss](https://user-images.githubusercontent.com/7026881/82150975-5d6b1980-985a-11ea-86b5-ca58d784f316.png)

Press F5

![ss](https://user-images.githubusercontent.com/7026881/82151180-a3c07880-985a-11ea-83ad-aad59532a83e.png)

Profit

**Test plan**

Remove a job and press F5.

**Closing issues**

fixes #157 
