### PR TITLE
Don't expose ursadb by default for prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,6 @@ services:
     build:
       context: ursadb/
       dockerfile: Dockerfile
-    ports:
-    - "9281:9281"
     volumes:
     - "${SAMPLES_DIR}:/mnt/samples"
     - "${INDEX_DIR}:/var/lib/ursadb"


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
We explain in the documentation that exposing `ursadb` to unauthenticated users is dangerous, and yet we do it by default in supposedly `production` docker-compose.

**What is the new behaviour?**
We don't expose ursadb by default, but only for developer environments.

**Test plan**
Start ursadb with the default docker-compose,
try to connect with netcat to port 9281 - connection should be refused 

