### PR TITLE
Disable timeouts during indexing

### DIFF
--- a/src/utils/index.py
+++ b/src/utils/index.py
@@ -56,7 +56,9 @@ def index_files(
     ursa_url, types, tags, batch, compact_threshold = proc_params
     ursa = UrsaDb(ursa_url)
 
-    current_datasets = len(ursa.topology()["result"]["datasets"])
+    current_datasets = len(
+        ursa.execute_command("topology;")["result"]["datasets"]
+    )
     if current_datasets > compact_threshold:
         ursa.execute_command("compact smart;")
 
@@ -146,7 +148,9 @@ def index(
         working_datasets = workers * 20 + 40
 
     ursa = UrsaDb(ursadb)
-    current_datasets = len(ursa.topology()["result"]["datasets"])
+    current_datasets = len(
+        ursa.execute_command("topology;")["result"]["datasets"]
+    )
     compact_threshold = current_datasets + working_datasets
 
     logging.info("Index.1: Compact threshold = %s.", compact_threshold)


### PR DESCRIPTION
Indexing can take a long time, and sometimes workers can all
be busy for a while. We don't want to crash whole indexing because one
of the indexing jobs took more than 1 second to query backend for a list of
datasets.

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [n/a] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [n/a] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
One of the queries during indexing can timeout, which will bring down the whole indexing operation.

**What is the new behaviour?**
No timeouts for `topology` requests.

**Test plan**
You probably have to just believe me. Or maybe run utils.index script with more workers than configured in ursadb instance - one of them will timeout and crash the job.