### PR TITLE
Expose ursadb, but only on localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     build:
       context: ursadb/
       dockerfile: Dockerfile
+    ports:
+    - "127.0.0.1:9281:9281"
     volumes:
     - "${SAMPLES_DIR}:/mnt/samples"
     - "${INDEX_DIR}:/var/lib/ursadb"


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Last change here I hope.

The docker-compose is secure now, because it doesn't expose its port on the internet, but it's also not accessible outside of the docker world.

**What is the new behaviour?**
ursadb exposes its control port, but only on localhost

**Test plan**
Start a service

Connect to the 127.0.0.1 9281 using netcat -vvv

