### PR TITLE
Monaco/resetContents workaround

### DIFF
--- a/src/mqueryfront/src/QueryMonaco.js
+++ b/src/mqueryfront/src/QueryMonaco.js
@@ -74,6 +74,15 @@ class QueryMonaco extends Component {
         if (this.props.error !== prevProps.error) {
             this.setError(...this.props.error);
         }
+
+        //workaround for clearing editor content
+        if (
+            prevProps.rawYara !== "" &&
+            this.props.rawYara === "" &&
+            prevProps.readOnly &&
+            !this.props.readOnly
+        )
+            this.editor.setValue("");
     }
 
     render() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Sometimes Monaco editor does not clear its contents in reaction on logo or Query button.

**What is the new behaviour?**
Now Monaco editor clears its contents.
