### PR TITLE
Refactor of QueryPage and related components

### DIFF
--- a/src/mqueryfront/src/QueryField.js
+++ b/src/mqueryfront/src/QueryField.js
@@ -1,93 +1,12 @@
 import React, { Component } from "react";
-import axios from "axios";
-import { API_URL } from "./config";
 import QueryMonaco from "./QueryMonaco";
 
 class QueryField extends Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            selectedTaint: null,
-            error: null,
-        };
-
-        this.handleInputChange = this.handleInputChange.bind(this);
-        this.handleYaraChanged = this.handleYaraChanged.bind(this);
-        this.handleQuery = this.handleQuery.bind(this);
-        this.handleEdit = this.handleEdit.bind(this);
-    }
-
-    componentDidMount() {}
-
-    selectTaint(newTaint) {
-        this.setState({
-            selectedTaint: newTaint,
-        });
-    }
-
     describeTaint() {
-        if (this.state.selectedTaint == null) {
+        if (this.props.selectedTaint == null) {
             return "everywhere";
         }
-        return this.state.selectedTaint;
-    }
-
-    handleYaraChanged(value) {
-        this.props.updateYara(value);
-    }
-
-    handleQuery(event, method, priority) {
-        const yara = this.props.rawYara;
-        axios
-            .create()
-            .post(API_URL + "/query", {
-                raw_yara: yara,
-                method: method,
-                priority: priority,
-                taint: this.state.selectedTaint,
-            })
-            .then((response) => {
-                if (method === "query") {
-                    this.props.updateQhash(response.data.query_hash, yara);
-                } else if (method === "parse") {
-                    this.props.updateQueryPlan(response.data, yara);
-                }
-            })
-            .catch((error) => {
-                let err = error.toString();
-
-                if (error.response) {
-                    err = error.response.data.detail;
-                    // Dirty hack to parse error lines from the error message
-                    // Error format: "Error at 4.2-7:" or  "Error at 5.1:"
-                    let parsedError = err.match(
-                        /Error at (\d+).(\d+)-?(\d+)?: (.*)/
-                    );
-                    if (parsedError) {
-                        this.setState({ error: parsedError });
-                    }
-                }
-
-                this.props.updateQueryError(err, this.props.rawYara);
-            });
-
-        event.preventDefault();
-    }
-
-    handleInputChange(event) {
-        const target = event.target;
-        const value =
-            target.type === "checkbox" ? target.checked : target.value;
-        const name = target.name;
-
-        this.setState({
-            [name]: value,
-        });
-    }
-
-    handleEdit(event) {
-        this.props.updateQhash(null);
+        return this.props.selectedTaint;
     }
 
     render() {
@@ -97,9 +16,10 @@ class QueryField extends Component {
                     <button
                         type="button"
                         className="btn btn-success btn-sm"
-                        onClick={(event) =>
-                            this.handleQuery(event, "query", "medium")
-                        }
+                        onClick={(event) => {
+                            event.preventDefault();
+                            this.props.submitQuery("query", "medium");
+                        }}
                     >
                         Query
                     </button>
@@ -114,25 +34,28 @@ class QueryField extends Component {
                         <div className="dropdown-menu">
                             <button
                                 className="dropdown-item"
-                                onClick={(event) =>
-                                    this.handleQuery(event, "query", "low")
-                                }
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    this.props.submitQuery("query", "low");
+                                }}
                             >
                                 Low Priority Query
                             </button>
                             <button
                                 className="dropdown-item"
-                                onClick={(event) =>
-                                    this.handleQuery(event, "query", "medium")
-                                }
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    this.props.submitQuery("query", "medium");
+                                }}
                             >
                                 Standard Priority Query
                             </button>
                             <button
                                 className="dropdown-item"
-                                onClick={(event) =>
-                                    this.handleQuery(event, "query", "high")
-                                }
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    this.props.submitQuery("query", "high");
+                                }}
                             >
                                 High Priority Query
                             </button>
@@ -143,7 +66,7 @@ class QueryField extends Component {
                             className="btn btn-secondary btn-sm"
                             name="clone"
                             type="submit"
-                            onClick={this.handleEdit}
+                            onClick={this.props.editQuery}
                         >
                             <span className="fa fa-clone" /> Edit
                         </button>
@@ -152,9 +75,10 @@ class QueryField extends Component {
                             className="btn btn-secondary btn-sm"
                             name="parse"
                             type="submit"
-                            onClick={(event) =>
-                                this.handleQuery(event, "parse", null)
-                            }
+                            onClick={(event) => {
+                                event.preventDefault();
+                                this.props.submitQuery("parse");
+                            }}
                         >
                             <span className="fa fa-code" /> Parse
                         </button>
@@ -172,7 +96,9 @@ class QueryField extends Component {
                         <div className="dropdown-menu">
                             <button
                                 className="dropdown-item"
-                                onClick={(event) => this.selectTaint(null)}
+                                onClick={(event) =>
+                                    this.props.selectTaint(null)
+                                }
                             >
                                 everywhere
                             </button>
@@ -181,7 +107,7 @@ class QueryField extends Component {
                                     <button
                                         className="dropdown-item"
                                         onClick={(event) =>
-                                            this.selectTaint(taint)
+                                            this.props.selectTaint(taint)
                                         }
                                     >
                                         {taint}
@@ -194,9 +120,9 @@ class QueryField extends Component {
                 <div className="mt-1 monaco-container">
                     <QueryMonaco
                         readOnly={this.props.readOnly}
-                        onValueChanged={this.handleYaraChanged}
+                        onValueChanged={this.props.updateYara}
                         rawYara={this.props.rawYara}
-                        error={this.state.error}
+                        error={this.props.error}
                     />
                 </div>
             </div>

--- a/src/mqueryfront/src/QueryField.js
+++ b/src/mqueryfront/src/QueryField.js
@@ -2,13 +2,6 @@ import React, { Component } from "react";
 import QueryMonaco from "./QueryMonaco";
 
 class QueryField extends Component {
-    describeTaint() {
-        if (this.props.selectedTaint == null) {
-            return "everywhere";
-        }
-        return this.props.selectedTaint;
-    }
-
     render() {
         return (
             <div>
@@ -16,8 +9,7 @@ class QueryField extends Component {
                     <button
                         type="button"
                         className="btn btn-success btn-sm"
-                        onClick={(event) => {
-                            event.preventDefault();
+                        onClick={() => {
                             this.props.submitQuery("query", "medium");
                         }}
                     >
@@ -34,8 +26,7 @@ class QueryField extends Component {
                         <div className="dropdown-menu">
                             <button
                                 className="dropdown-item"
-                                onClick={(event) => {
-                                    event.preventDefault();
+                                onClick={() => {
                                     this.props.submitQuery("query", "low");
                                 }}
                             >
@@ -43,8 +34,7 @@ class QueryField extends Component {
                             </button>
                             <button
                                 className="dropdown-item"
-                                onClick={(event) => {
-                                    event.preventDefault();
+                                onClick={() => {
                                     this.props.submitQuery("query", "medium");
                                 }}
                             >
@@ -52,8 +42,7 @@ class QueryField extends Component {
                             </button>
                             <button
                                 className="dropdown-item"
-                                onClick={(event) => {
-                                    event.preventDefault();
+                                onClick={() => {
                                     this.props.submitQuery("query", "high");
                                 }}
                             >
@@ -75,8 +64,7 @@ class QueryField extends Component {
                             className="btn btn-secondary btn-sm"
                             name="parse"
                             type="submit"
-                            onClick={(event) => {
-                                event.preventDefault();
+                            onClick={() => {
                                 this.props.submitQuery("parse");
                             }}
                         >
@@ -91,14 +79,12 @@ class QueryField extends Component {
                             aria-haspopup="true"
                             aria-expanded="false"
                         >
-                            Search: {this.describeTaint()}
+                            Search: {this.props.selectedTaint || "everywhere"}
                         </button>
                         <div className="dropdown-menu">
                             <button
                                 className="dropdown-item"
-                                onClick={(event) =>
-                                    this.props.selectTaint(null)
-                                }
+                                onClick={() => this.props.selectTaint(null)}
                             >
                                 everywhere
                             </button>
@@ -106,7 +92,7 @@ class QueryField extends Component {
                                 return (
                                     <button
                                         className="dropdown-item"
-                                        onClick={(event) =>
+                                        onClick={() =>
                                             this.props.selectTaint(taint)
                                         }
                                     >

--- a/src/mqueryfront/src/QueryMonaco.js
+++ b/src/mqueryfront/src/QueryMonaco.js
@@ -81,8 +81,9 @@ class QueryMonaco extends Component {
             this.props.rawYara === "" &&
             prevProps.readOnly &&
             !this.props.readOnly
-        )
+        ) {
             this.editor.setValue("");
+        }
     }
 
     render() {

--- a/src/mqueryfront/src/QueryPage.js
+++ b/src/mqueryfront/src/QueryPage.js
@@ -141,11 +141,7 @@ class QueryPage extends Component {
                 "&limit=" +
                 LIMIT
         );
-        if (response) {
-            const { job, matches } = response.data;
-            return { job, matches };
-        }
-        return {};
+        return response ? response.data : {};
     }
 
     collapsePane() {

--- a/src/mqueryfront/src/QueryPage.js
+++ b/src/mqueryfront/src/QueryPage.js
@@ -8,14 +8,13 @@ import { isStatusFinished } from "./queryUtils";
 import ToggleLayoutButton from "./components/ToggleLayoutButton";
 
 const INITIAL_STATE = {
-    mode: "query",
     collapsed: false,
-    qhash: null,
     rawYara: "",
     queryPlan: null,
     queryError: null,
     datasets: {},
-    matches: null,
+    matches: [],
+    selectedTaint: null,
     job: null,
     activePage: 1,
 };
@@ -24,49 +23,71 @@ class QueryPage extends Component {
     constructor(props) {
         super(props);
 
-        let initialState = { ...INITIAL_STATE };
-        if (this.props.match.params.hash) {
-            initialState.qhash = this.props.match.params.hash;
-        }
-        this.state = initialState;
+        this.state = { ...INITIAL_STATE };
+        this.trackJobTimeout = null;
 
-        this.updateQhash = this.updateQhash.bind(this);
-        this.updateQueryError = this.updateQueryError.bind(this);
-        this.updateQueryPlan = this.updateQueryPlan.bind(this);
         this.collapsePane = this.collapsePane.bind(this);
         this.updateYara = this.updateYara.bind(this);
+        this.setActivePage = this.setActivePage.bind(this);
+        this.submitQuery = this.submitQuery.bind(this);
+        this.editQuery = this.editQuery.bind(this);
+        this.selectTaint = this.selectTaint.bind(this);
+    }
+
+    get queryHash() {
+        return this.props.match.params.hash;
     }
 
     componentDidMount() {
-        if (this.state.qhash) {
-            axios.get(API_URL + "/job/" + this.state.qhash).then((response) => {
-                this.updateQhash(this.state.qhash, response.data.raw_yara);
-            });
+        if (this.queryHash) {
+            this.fetchJob();
         }
         axios.get(API_URL + "/backend/datasets").then((response) => {
             this.setState({ datasets: response.data.datasets });
         });
     }
 
-    componentWillUnmount() {
-        if (this.timeout !== null) {
-            clearTimeout(this.timeout);
-        }
+    async fetchJob() {
+        // Go to the job mode
+        // Load initial job information and start tracking results
+        let response = await axios.get(API_URL + "/job/" + this.queryHash);
+        this.setState(
+            {
+                ...INITIAL_STATE,
+                rawYara: response.data.raw_yara,
+                collapsed: true,
+                job: response.data,
+                datasets: this.state.datasets,
+            },
+            () => {
+                this.trackJob();
+            }
+        );
+    }
 
-        this.setState({
-            qhash: null,
-        });
+    componentWillUnmount() {
+        this.cancelJob();
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (
-            this.props.match.path === "/" &&
-            this.props.location.key !== prevProps.location.key &&
-            (typeof this.props.location.state === "undefined" ||
-                typeof this.props.location.state.internal === "undefined" ||
-                !this.props.location.state.internal)
-        ) {
-            this.setState(INITIAL_STATE);
+        const prevQueryHash = prevProps.match.params.hash;
+        if (this.queryHash) {
+            if (prevQueryHash !== this.queryHash) {
+                // Went to the job mode or switched to another job
+                this.cancelJob();
+                this.fetchJob();
+            }
+        } else if (this.props.location.key !== prevProps.location.key) {
+            let editMode =
+                this.props.location.state &&
+                this.props.location.state.editQuery;
+            // Refresh view into query mode
+            this.cancelJob();
+            this.setState({
+                ...INITIAL_STATE,
+                datasets: this.state.datasets,
+                rawYara: editMode ? this.state.rawYara : "",
+            });
         }
     }
 
@@ -77,115 +98,54 @@ class QueryPage extends Component {
         return [...new Set(taintList)];
     }
 
-    updateQhash(newQhash, rawYara) {
-        if (typeof rawYara !== "undefined") {
-            this.setState({ rawYara: rawYara });
-        }
-
-        let path;
-        if (!newQhash) {
-            path = "/";
-        } else {
-            path = "/query/" + newQhash;
-            this.collapsePane();
-        }
-        this.props.history.push(path, { internal: true });
-
-        this.setState({
-            mode: "job",
-            queryError: null,
-            queryPlan: null,
-            qhash: newQhash,
-            matches: null,
-            job: null,
-            activePage: 1,
-        });
-        this.loadJob();
-    }
-
     updateYara(value) {
         this.setState({ rawYara: value });
     }
 
-    loadJob() {
-        const LIMIT = 20;
-        let OFFSET = (this.state.activePage - 1) * 20;
+    async trackJob() {
+        // Periodically reloads job status until job is finished
+        let { job, matches } = await this.loadMatches();
 
-        if (!this.state.qhash) {
-            return;
+        this.setState({ job, matches });
+        if (!isStatusFinished(job.status)) {
+            this.trackJobTimeout = setTimeout(() => this.trackJob(), 1000);
+        } else {
+            this.trackJobTimeout = null;
         }
-
-        axios
-            .get(
-                API_URL +
-                    "/matches/" +
-                    this.state.qhash +
-                    "?offset=" +
-                    OFFSET +
-                    "&limit=" +
-                    LIMIT
-            )
-            .then((response) => {
-                const { job, matches } = response.data;
-
-                this.setState({
-                    job: job,
-                    matches: matches,
-                });
-                const isDone = isStatusFinished(job.status);
-                if (isDone) {
-                    return;
-                }
-                this.timeout = setTimeout(() => this.loadJob(), 1000);
-            });
     }
 
-    callbackResultsActivePage = (pageNumber) => {
-        this.setState({ activePage: pageNumber }, () => {
-            this.loadMatches();
-        });
-    };
+    cancelJob() {
+        // Cancels perodic job status reload
+        if (this.trackJobTimeout !== null) {
+            clearTimeout(this.trackJobTimeout);
+            this.trackJobTimeout = null;
+        }
+    }
 
-    loadMatches() {
+    setActivePage(pageNumber) {
+        this.setState({ activePage: pageNumber }, async () => {
+            this.setState(await this.loadMatches());
+        });
+    }
+
+    async loadMatches() {
+        // Loads matches from the current page
         const LIMIT = 20;
-        let OFFSET = (this.state.activePage - 1) * 20;
-        axios
-            .get(
-                API_URL +
-                    "/matches/" +
-                    this.state.qhash +
-                    "?offset=" +
-                    OFFSET +
-                    "&limit=" +
-                    LIMIT
-            )
-            .then((response) => {
-                this.setState({
-                    matches: response.data.matches,
-                });
-            });
-    }
-
-    updateQueryError(newError, rawYara) {
-        this.setState({
-            mode: "query",
-            queryError: newError,
-            queryPlan: null,
-            rawYara: rawYara,
-            job: null,
-            matches: null,
-        });
-    }
-
-    updateQueryPlan(parsedQuery, rawYara) {
-        this.setState({
-            mode: "query",
-            queryPlan: parsedQuery,
-            queryError: null,
-            rawYara: rawYara,
-            job: null,
-            matches: null,
-        });
+        const OFFSET = (this.state.activePage - 1) * LIMIT;
+        const response = await axios.get(
+            API_URL +
+                "/matches/" +
+                this.queryHash +
+                "?offset=" +
+                OFFSET +
+                "&limit=" +
+                LIMIT
+        );
+        if (response) {
+            const { job, matches } = response.data;
+            return { job, matches };
+        }
+        return {};
     }
 
     collapsePane() {
@@ -194,10 +154,59 @@ class QueryPage extends Component {
         }));
     }
 
+    async submitQuery(method, priority) {
+        try {
+            let response = await axios.post(API_URL + "/query", {
+                raw_yara: this.state.rawYara,
+                method: method,
+                priority: priority,
+                taint: this.state.selectedTaint,
+            });
+            if (method === "query") {
+                this.props.history.push("/query/" + response.data.query_hash);
+            } else if (method === "parse") {
+                this.setState({
+                    queryPlan: response.data,
+                    queryError: null,
+                });
+            }
+        } catch (error) {
+            this.setState({
+                queryError: error.response
+                    ? error.response.data.detail
+                    : error.toString(),
+                queryPlan: null,
+            });
+        }
+    }
+
+    get parsedError() {
+        if (this.state.queryError) {
+            // Dirty hack to parse error lines from the error message
+            // Error format: "Error at 4.2-7:" or  "Error at 5.1:"
+            let parsedError = this.state.queryError.match(
+                /Error at (\d+).(\d+)-?(\d+)?: (.*)/
+            );
+            if (parsedError) return parsedError;
+        }
+        return [];
+    }
+
+    editQuery() {
+        // Goes to the query mode keeping the original query
+        this.props.history.push("/", { editQuery: this.queryHash });
+    }
+
+    selectTaint(newTaint) {
+        this.setState({
+            selectedTaint: newTaint,
+        });
+    }
+
     render() {
         const queryParse = (
             <QueryParseStatus
-                qhash={this.state.qhash}
+                qhash={this.queryHash}
                 queryPlan={this.state.queryPlan}
                 queryError={this.state.queryError}
             />
@@ -211,10 +220,10 @@ class QueryPage extends Component {
                     label={this.state.collapsed ? "Show query" : "Hide query"}
                 />
                 <QueryResultsStatus
-                    qhash={this.state.qhash}
+                    qhash={this.queryHash}
                     job={this.state.job}
                     matches={this.state.matches}
-                    parentCallback={this.callbackResultsActivePage}
+                    parentCallback={this.setActivePage}
                     collapsed={this.state.collapsed}
                 />
             </div>
@@ -226,12 +235,13 @@ class QueryPage extends Component {
                         <div className="col-md-5">
                             <QueryField
                                 rawYara={this.state.rawYara}
-                                readOnly={!!this.state.qhash}
-                                updateQhash={this.updateQhash}
+                                error={this.parsedError}
+                                readOnly={!!this.queryHash}
                                 availableTaints={this.availableTaints()}
-                                updateQueryPlan={this.updateQueryPlan}
-                                updateQueryError={this.updateQueryError}
                                 updateYara={this.updateYara}
+                                submitQuery={this.submitQuery}
+                                editQuery={this.editQuery}
+                                selectTaint={this.selectTaint}
                             />
                         </div>
                     ) : (
@@ -242,7 +252,7 @@ class QueryPage extends Component {
                             this.state.collapsed ? "col-md-12" : "col-md-7"
                         }
                     >
-                        {this.state.mode === "query"
+                        {!this.queryHash
                             ? queryParse
                             : this.state.job
                             ? queryResults


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)

**What is the new behaviour?**
- Using props for getting qhash from path (`/query/<hash>`) instead of derived state
- Removed redundant `this.state.mode`: QueryPage is considered to be in "job" mode always if `queryHash` is set.
- Query submission method has been lifted from `QueryField` component to the `QueryPage` component (`handleQuery` => `this.props.submitQuery`)
- Instead of setting `internal` location state for all internal redirects, `{ editQuery: this.queryHash }` is set when we want to go to `/` and keep rawYara from the current job (`QueryPage.editQuery` method).

Other (minor) changes:
- Methods that send requests to API are now `async`
- Removed unused methods `QueryField.handleInputChange` and `QueryField.componentDidMount` and unnecessary `QueryField.handleYaraChanged`

**Fixed the following bugs:**
- If logo or `Edit` was clicked during the job - timeout was still active, because it was cleared only when component unmounts
- `datasets` were wiped from state after clicking logo or `Query` navitem (they're fetched only after mount)
