### PR TITLE
Enable mwdb plugin by default in our instance.

### DIFF
--- a/deploy/k8s/daemon.yml
+++ b/deploy/k8s/daemon.yml
@@ -17,11 +17,23 @@ spec:
         app: mquery-daemon
     spec:
       containers:
-      - envFrom:
-        - configMapRef:
-            name: mquery-config
-        - secretRef:
-            name: mquery-secret
+      - env:
+        - name: MWDB_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: secret-mquery-mwdb-token
+              key: token
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-mquery-secret-key
+              key: key
+        - name: REDIS_HOST
+          value: redis
+        - name: REDIS_PORT
+          value: "6379"
+        - name: MQUERY_PLUGINS
+          value: "plugins.mwdb_uploads:MalwarecageUploadsMetadata"
         image: dr.cert.pl/mquery/mquery_daemon:latest
         imagePullPolicy: Always
         name: mquery-daemon-container

--- a/deploy/k8s/web.yml
+++ b/deploy/k8s/web.yml
@@ -17,11 +17,21 @@ spec:
         app: mquery-web
     spec:
       containers:
-      - envFrom:
-        - configMapRef:
-            name: mquery-config
-        - secretRef:
-            name: mquery-secret
+      - env:
+        - name: MWDB_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: secret-mquery-mwdb-token
+              key: token
+        - name: SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: secret-mquery-secret-key
+              key: key
+        - name: REDIS_HOST
+          value: redis
+        - name: REDIS_PORT
+          value: "6379"
         image: dr.cert.pl/mquery/mquery_web:latest
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
Part of mwdb/mquery integration.

TODO: remove these configs from this repo :thinking:

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [n/a] I've added automated tests for my change (if applicable, optional)
- [n/a] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Mwdb plugin is disabled by default in our internal instance. We want to integrate it with `mwdb.cert.pl`, and thus enable this plugin by default.

**What is the new behaviour?**
Mwdb plugin is enabled. I've also refactored configmaps to variables, because I feel it's a better approach.

**Test plan**
Working on it with @psrok1.

fixes #issuenumber
