### PR TITLE
Mount new storage locations to production

### DIFF
--- a/deploy/k8s/daemon.yml
+++ b/deploy/k8s/daemon.yml
@@ -44,6 +44,8 @@ spec:
           name: mquery-nfs-volume-prod
         - mountPath: /mnt/kuku-analyses
           name: mquery-nfs-analyses-volume-prod
+        - mountPath: /mnt/binaries
+          name: mquery-cuckoo-binaries-volume-prod
       dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: dr-auth
@@ -60,3 +62,6 @@ spec:
       - name: mquery-nfs-analyses-volume-prod
         persistentVolumeClaim:
           claimName: mquery-nfs-analyses-claim-prod
+      - name: mquery-cuckoo-binaries-volume-prod
+        persistentVolumeClaim:
+          claimName: mquery-cuckoo-binaries-pv-claim-prod

--- a/deploy/k8s/web.yml
+++ b/deploy/k8s/web.yml
@@ -52,6 +52,8 @@ spec:
           name: mquery-nfs-volume-prod
         - mountPath: /mnt/kuku-analyses
           name: mquery-nfs-analyses-volume-prod
+        - mountPath: /mnt/binaries
+          name: mquery-cuckoo-binaries-volume-prod
       dnsPolicy: ClusterFirst
       imagePullSecrets:
       - name: dr-auth
@@ -68,6 +70,10 @@ spec:
       - name: mquery-nfs-analyses-volume-prod
         persistentVolumeClaim:
           claimName: mquery-nfs-analyses-claim-prod
+      - name: mquery-cuckoo-binaries-volume-prod
+        persistentVolumeClaim:
+          claimName: mquery-cuckoo-binaries-pv-claim-prod
+
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [n/a] I've added automated tests for my change (if applicable, optional)
- [n/a] I've updated documentation to reflect my change (if applicable)

Internal change - due to the incoming mwdb+mquery integration we want to index mwdb binaries in a different way

**What is the current behaviour?**
mwdb binaries are not indexed directly in cert internal mquery

**What is the new behaviour?**
mwdb binaries are mounted directly, and can be indexed.

**Test plan**
index the new directory, and ensure that all mwdb binaries are accessible.

