### PR TITLE
Expose job error in JobSchema

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -94,6 +94,7 @@ class Database:
         return JobSchema(
             id=job.hash,
             status=data.get("status", "ERROR"),
+            error=data.get("error", None),
             rule_name=data.get("rule_name", "ERROR"),
             rule_author=data.get("rule_author", None),
             raw_yara=data.get("raw_yara", "ERROR"),

--- a/src/mqueryfront/src/query/QueryResultsStatus.js
+++ b/src/mqueryfront/src/query/QueryResultsStatus.js
@@ -9,10 +9,6 @@ const QueryResultsStatus = (props) => {
     const { job, matches, qhash, pagination, onCancel } = props;
     const { status, files_matched } = job;
 
-    if (job.error) {
-        return <ErrorPage error={job.error} />;
-    }
-
     if (status === "expired") {
         return (
             <div className="mquery-scroll-matches">
@@ -21,18 +17,25 @@ const QueryResultsStatus = (props) => {
         );
     }
 
-    const results =
-        files_matched === 0 ? (
-            status === "done" ? (
-                <div className="alert alert-info">No matches found.</div>
-            ) : null
-        ) : (
+    let results = null;
+
+    if (job.error) {
+        results = (
+            <div className="alert alert-danger">
+                <b>Job error occured</b>: {job.error}
+            </div>
+        );
+    } else if (files_matched > 0) {
+        results = (
             <QueryMatches
                 matches={matches}
                 qhash={qhash}
                 pagination={pagination}
             />
         );
+    } else if (status === "done") {
+        results = <div className="alert alert-info">No matches found.</div>;
+    }
 
     return (
         <div>

--- a/src/schema.py
+++ b/src/schema.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 class JobSchema(BaseModel):
     id: str
     status: str
+    error: Optional[str]
     rule_name: str
     rule_author: Optional[str]
     raw_yara: str


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
- Job error message is not exposed in API so we don't know the reason of `failed` status.
- Job error was already supported in frontend, but it was dead code

**What is the new behaviour?**
- Added job error to JobSchema so the message is exposed by `/api/job/{job_id}` endpoint
- Rendering `ErrorPage` instead of `QueryResultsStatus` was not very elegant. In most cases `failed` status was caused by serious bugs, so it *could be* reasonable to hold everything and show kind of Red Alert of Death message. But now, it can be caused also by exceeding the file limit - situation that can be fixed by user itself by editing the query and making it more specific.

Before change in frontend:

![image](https://user-images.githubusercontent.com/8720367/84153249-eb0ae500-aa65-11ea-8bf0-aa50da8e05ff.png)

After change:

![image](https://user-images.githubusercontent.com/8720367/84152839-733cba80-aa65-11ea-8e30-ba3f06d8767f.png)
