### PR TITLE
Bind ctrl+enter to submit query action in the editor

### DIFF
--- a/src/mqueryfront/src/query/QueryField.js
+++ b/src/mqueryfront/src/query/QueryField.js
@@ -21,6 +21,7 @@ const QueryField = (props) => {
                     rawYara={props.rawYara}
                     onValueChanged={props.onYaraUpdate}
                     error={props.parsedError}
+                    onSubmitQuery={props.onSubmitQuery}
                 />
             </div>
         </div>

--- a/src/mqueryfront/src/query/QueryMonaco.js
+++ b/src/mqueryfront/src/query/QueryMonaco.js
@@ -57,6 +57,12 @@ class QueryMonaco extends Component {
                         ]);
                     }
                 });
+                editor.addCommand(
+                    [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+                    () => {
+                        this.props.onSubmitQuery("medium");
+                    }
+                );
             })
             .catch((error) =>
                 console.error(


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [n/a yet] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
User has to click the "query" button to run the query

**What is the new behaviour?**
Ctrl+enter from the editor submits the query

**Test plan**
Start mquery, write a dummy yara rule, press ctrl+enter
**Closing issues**

fixes #194 