### PR TITLE
Add rule name filter for matched samples

### DIFF
--- a/src/mqueryfront/src/App.css
+++ b/src/mqueryfront/src/App.css
@@ -83,3 +83,7 @@
     cursor: pointer;
     color: var(--blue) !important;
 }
+
+.cursor-pointer{
+    cursor: pointer;
+  }

--- a/src/mqueryfront/src/App.css
+++ b/src/mqueryfront/src/App.css
@@ -84,6 +84,6 @@
     color: var(--blue) !important;
 }
 
-.cursor-pointer{
+.cursor-pointer {
     cursor: pointer;
-  }
+}

--- a/src/mqueryfront/src/components/FilterIcon.js
+++ b/src/mqueryfront/src/components/FilterIcon.js
@@ -17,7 +17,7 @@ const FilterIcon = (props) => {
 
 FilterIcon.defaultProps = {
     size: "xs",
-    color: "black",
+    color: undefined,
     tooltipMessage: "filter",
 };
 

--- a/src/mqueryfront/src/components/FilterIcon.js
+++ b/src/mqueryfront/src/components/FilterIcon.js
@@ -17,7 +17,6 @@ const FilterIcon = (props) => {
 
 FilterIcon.defaultProps = {
     size: "xs",
-    color: undefined,
     tooltipMessage: "filter",
 };
 

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -94,7 +94,7 @@ const QueryMatches = (props) => {
                             </span>
                             {filters.length > 0 && (
                                 <span className="border rounded p-1 pull-right text-secondary">
-                                    <FilterIcon color="text-secondary" />
+                                    <FilterIcon />
                                     {filtersHead}
                                 </span>
                             )}

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -31,7 +31,7 @@ const QueryMatches = (props) => {
             }
         })
         .map((match, index) => {
-            const download_url =
+            const downloadUrl =
                 API_URL +
                 "/download?job_id=" +
                 encodeURIComponent(qhash) +
@@ -44,13 +44,23 @@ const QueryMatches = (props) => {
                 <QueryMatchesItem
                     key={match.file}
                     match={match}
-                    download_url={download_url}
+                    download_url={downloadUrl}
                     filters={filters}
                     setFilter={setFilter}
                     changeFilter={updateFilter}
                 />
             );
         });
+
+    const filtersHead = filters.map((v) => (
+        <span
+            key={v}
+            className="badge badge-pill badge-primary ml-1 mt-1  cursor-pointer"
+            onClick={() => updateFilter(v)}
+        >
+            {v}
+        </span>
+    ));
 
     const downloadDropdownList = [
         {
@@ -82,15 +92,7 @@ const QueryMatches = (props) => {
                                     itemList={downloadDropdownList}
                                 />
                             </span>
-                            {filters.map((v) => (
-                                <span
-                                    key={v}
-                                    className="badge badge-pill badge-primary ml-1 mt-1"
-                                    onClick={() => updateFilter(v)}
-                                >
-                                    {v}
-                                </span>
-                            ))}
+                            {filtersHead}
                         </th>
                     </tr>
                 </thead>

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -55,7 +55,7 @@ const QueryMatches = (props) => {
     const filtersHead = filters.map((v) => (
         <span
             key={v}
-            className="badge badge-pill badge-primary ml-1 mt-1  cursor-pointer"
+            className="badge badge-pill badge-secondary ml-1 mt-1  cursor-pointer"
             onClick={() => updateFilter(v)}
         >
             {v}
@@ -93,8 +93,8 @@ const QueryMatches = (props) => {
                                 />
                             </span>
                             {filters.length > 0 && (
-                                <span class="border rounded p-1 pull-right">
-                                    <FilterIcon color="grey" />
+                                <span class="border rounded p-1 pull-right text-secondary">
+                                    <FilterIcon color="text-secondary" />
                                     {filtersHead}
                                 </span>
                             )}

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -94,7 +94,7 @@ const QueryMatches = (props) => {
                             </span>
                             {filters.length > 0 && (
                                 <span class="border rounded p-1 pull-right">
-                                    <FilterIcon />
+                                    <FilterIcon color="grey" />
                                     {filtersHead}
                                 </span>
                             )}

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { API_URL } from "../config";
 import Pagination from "react-js-pagination";
+import FilterIcon from "../components/FilterIcon";
 import DownloadDropdown from "../components/DownloadDropdown";
 import QueryMatchesItem from "./QueryMatchesItem";
 import PropTypes from "prop-types";
@@ -93,7 +94,7 @@ const QueryMatches = (props) => {
                             </span>
                             {filters.length > 0 && (
                                 <span class="border rounded p-1 pull-right">
-                                    <i class="fa fa-filter text-secondary mr-2"></i>
+                                    <FilterIcon />
                                     {filtersHead}
                                 </span>
                             )}

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { API_URL } from "../config";
 import Pagination from "react-js-pagination";
 import DownloadDropdown from "../components/DownloadDropdown";
@@ -9,24 +9,48 @@ import { PT_MATCHES, PT_PAGINATION } from "../queryUtils";
 const QueryMatches = (props) => {
     const { matches, qhash, pagination } = props;
 
-    const matchesList = matches.map((match, index) => {
-        const download_url =
-            API_URL +
-            "/download?job_id=" +
-            encodeURIComponent(qhash) +
-            "&ordinal=" +
-            encodeURIComponent(index) +
-            "&file_path=" +
-            encodeURIComponent(match.file);
+    const [filters, setFilter] = useState([]);
 
-        return (
-            <QueryMatchesItem
-                key={match.file}
-                match={match}
-                download_url={download_url}
-            />
-        );
-    });
+    const updateFilter = (name) => {
+        if (!filters.includes(name)) {
+            setFilter([...filters, name]);
+        } else {
+            setFilter(filters.filter((e) => e !== name));
+        }
+    };
+
+    const matchesList = matches
+        .filter((match) => {
+            if (
+                filters.length > 0 &&
+                match.matches.some((v) => filters.includes(v))
+            ) {
+                return match;
+            } else {
+                return match;
+            }
+        })
+        .map((match, index) => {
+            const download_url =
+                API_URL +
+                "/download?job_id=" +
+                encodeURIComponent(qhash) +
+                "&ordinal=" +
+                encodeURIComponent(index) +
+                "&file_path=" +
+                encodeURIComponent(match.file);
+
+            return (
+                <QueryMatchesItem
+                    key={match.file}
+                    match={match}
+                    download_url={download_url}
+                    filters={filters}
+                    setFilter={setFilter}
+                    changeFilter={updateFilter}
+                />
+            );
+        });
 
     const downloadDropdownList = [
         {
@@ -58,6 +82,15 @@ const QueryMatches = (props) => {
                                     itemList={downloadDropdownList}
                                 />
                             </span>
+                            {filters.map((v) => (
+                                <span
+                                    key={v}
+                                    className="badge badge-pill badge-primary ml-1 mt-1"
+                                    onClick={() => updateFilter(v)}
+                                >
+                                    {v}
+                                </span>
+                            ))}
                         </th>
                     </tr>
                 </thead>

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -93,8 +93,8 @@ const QueryMatches = (props) => {
                                 />
                             </span>
                             {filters.length > 0 && (
-                                <span className="border rounded p-1 pull-right">
-                                    <FilterIcon color="grey" />
+                                <span className="border rounded p-1 pull-right text-secondary">
+                                    <FilterIcon />
                                     {filtersHead}
                                 </span>
                             )}

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -93,8 +93,8 @@ const QueryMatches = (props) => {
                                 />
                             </span>
                             {filters.length > 0 && (
-                                <span className="border rounded p-1 pull-right text-secondary">
-                                    <FilterIcon />
+                                <span className="border rounded p-1 pull-right">
+                                    <FilterIcon color="grey" />
                                     {filtersHead}
                                 </span>
                             )}

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -93,7 +93,7 @@ const QueryMatches = (props) => {
                                 />
                             </span>
                             {filters.length > 0 && (
-                                <span class="border rounded p-1 pull-right text-secondary">
+                                <span className="border rounded p-1 pull-right text-secondary">
                                     <FilterIcon color="text-secondary" />
                                     {filtersHead}
                                 </span>

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -21,11 +21,10 @@ const QueryMatches = (props) => {
 
     const matchesList = matches
         .filter((match) => {
-            if (
-                filters.length > 0 &&
-                match.matches.some((v) => filters.includes(v))
-            ) {
-                return match;
+            if (filters.length > 0) {
+                if (match.matches.some((v) => filters.includes(v))) {
+                    return match;
+                }
             } else {
                 return match;
             }

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -91,7 +91,12 @@ const QueryMatches = (props) => {
                                     itemList={downloadDropdownList}
                                 />
                             </span>
-                            {filtersHead}
+                            {filters.length > 0 && (
+                                <span class="border rounded p-1 pull-right">
+                                    <i class="fa fa-filter text-secondary mr-2"></i>
+                                    {filtersHead}
+                                </span>
+                            )}
                         </th>
                     </tr>
                 </thead>

--- a/src/mqueryfront/src/query/QueryMatchesItem.js
+++ b/src/mqueryfront/src/query/QueryMatchesItem.js
@@ -8,10 +8,6 @@ const QueryMatchesItem = (props) => {
     const { match, download_url } = props;
     const { matches, meta, file } = match;
 
-    const addFilter = (event) => {
-        props.changeFilter(event);
-    };
-
     const path = require("path");
     const fileBasename = path.basename(file);
 

--- a/src/mqueryfront/src/query/QueryMatchesItem.js
+++ b/src/mqueryfront/src/query/QueryMatchesItem.js
@@ -29,7 +29,7 @@ const QueryMatchesItem = (props) => {
         <span
             key={v}
             className="badge badge-pill badge-primary ml-1 mt-1 cursor-pointer"
-            onClick={() => addFilter(v)}
+            onClick={() => props.changeFilter(v)}
         >
             {v}
         </span>

--- a/src/mqueryfront/src/query/QueryMatchesItem.js
+++ b/src/mqueryfront/src/query/QueryMatchesItem.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import ActionDownload from "../components/ActionDownload";
 import ActionCopyToClipboard from "../components/ActionCopyToClipboard";
 import PropTypes from "prop-types";
@@ -7,6 +7,10 @@ import { PT_MATCH } from "../queryUtils";
 const QueryMatchesItem = (props) => {
     const { match, download_url } = props;
     const { matches, meta, file } = match;
+
+    const addFilter = (event) => {
+        props.changeFilter(event);
+    };
 
     const path = require("path");
     const fileBasename = path.basename(file);
@@ -22,7 +26,11 @@ const QueryMatchesItem = (props) => {
         ));
 
     const matchBadges = Object.values(matches).map((v) => (
-        <span key={v} className="badge badge-pill badge-primary ml-1 mt-1">
+        <span
+            key={v}
+            className="badge badge-pill badge-primary ml-1 mt-1"
+            onClick={() => addFilter(v)}
+        >
             {v}
         </span>
     ));

--- a/src/mqueryfront/src/query/QueryMatchesItem.js
+++ b/src/mqueryfront/src/query/QueryMatchesItem.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import ActionDownload from "../components/ActionDownload";
 import ActionCopyToClipboard from "../components/ActionCopyToClipboard";
 import PropTypes from "prop-types";
@@ -28,7 +28,7 @@ const QueryMatchesItem = (props) => {
     const matchBadges = Object.values(matches).map((v) => (
         <span
             key={v}
-            className="badge badge-pill badge-primary ml-1 mt-1"
+            className="badge badge-pill badge-primary ml-1 mt-1 cursor-pointer"
             onClick={() => addFilter(v)}
         >
             {v}


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)


**What is the new behaviour?**
Implement rule name filter which allows you to filter samples after clicking on the name of the rule in the results.

**Test plan**
Run different queries at the same time that match different samples and check if filtering works.

**Closing issues**

fixes #78 
