### PR TITLE
Remove unnecessary closing parenthesis

### DIFF
--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -112,7 +112,6 @@ const QueryMatches = (props) => {
                 itemClass="page-item"
                 linkClass="page-link"
             />
-            )
         </div>
     );
 };


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
There is an extra closing parenthesis on the query result subpage
![image](https://user-images.githubusercontent.com/2192416/87659996-abb76e80-c75e-11ea-9c84-e10dd682b0dc.png)


**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
There aren't (probably) any extra closing parenthesis on the query result subpage

**Test plan**
<!-- Explain how to test your changes -->

Build mqueryfront and confirm that the parenthesis isn't there and nothing else broke in progress

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
