### PR TITLE
Remove deprecated time.clock from ursadb client

### DIFF
--- a/src/lib/ursadb.py
+++ b/src/lib/ursadb.py
@@ -48,7 +48,7 @@ class UrsaDb:
     ) -> Json:
         socket = self.make_socket(recv_timeout=-1)
 
-        start = time.clock()
+        start = time.perf_counter()
         command = "select "
         if taints:
             taints_str = '", "'.join(taints)
@@ -62,7 +62,7 @@ class UrsaDb:
 
         response = socket.recv_string()
         socket.close()
-        end = time.clock()
+        end = time.perf_counter()
 
         res = json.loads(response)
 
@@ -76,7 +76,7 @@ class UrsaDb:
         file_count = res["result"]["file_count"]
 
         return {
-            "time": (end - start) * 1000,
+            "time": (end - start),
             "iterator": iterator,
             "file_count": file_count,
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
UrsaDB client  within mquery uses `time.clock` method that was removed in python 3.8. AFAIK this completely breaks the code on python3.8+

**What is the new behaviour?**
`time.clock` is replaced with `time.perf_counter` (added in python 3.3) which should work for all 3.6+ python versions.

**Test plan**
As far as I can see the `"time"` component from `UrsaDb.query` isn't really used anywhere :thinking:
E2E CI tests should make sure that there aren't any runtime errors.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
