### PR TITLE
Feature/OIDC

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,5 +50,12 @@ services:
     volumes:
     - "${SAMPLES_DIR}:/mnt/samples"
     - "${INDEX_DIR}:/var/lib/ursadb"
+  keycloak:
+    image: quay.io/keycloak/keycloak:15.1.0
+    ports:
+    - 8080:8080
+    environment:
+    - KEYCLOAK_USER=admin
+    - KEYCLOAK_PASSWORD=admin
   redis:
     image: redis

--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ from zmq import Again
 from lib.yaraparse import parse_yara
 
 from util import mquery_version
-from db import Database, JobId
+from db import Database, JobId, MQUERY_PLUGIN_NAME
 from typing import Any, Callable, List, Union, Dict, Iterable
 import tempfile
 import zipfile
@@ -33,6 +33,7 @@ from schema import (
     AgentSchema,
     ServerSchema,
 )
+
 
 db = Database(config.REDIS_HOST, config.REDIS_PORT)
 app = FastAPI()
@@ -319,7 +320,15 @@ def backend_status_datasets() -> BackendStatusDatasetsSchema:
 
 @app.get("/api/server", response_model=ServerSchema, tags=["stable"])
 def server() -> ServerSchema:
-    return ServerSchema(version=mquery_version())
+    return ServerSchema(
+        version=mquery_version(),
+        openid_auth_url=db.get_config_key(
+            MQUERY_PLUGIN_NAME, "openid_auth_url"
+        ),
+        openid_login_url=db.get_config_key(
+            MQUERY_PLUGIN_NAME, "openid_login_url"
+        ),
+    )
 
 
 @app.get("/query/{path}", include_in_schema=False)

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -124,7 +124,7 @@ class Agent:
         active_plugins = []
         for plugin_class in METADATA_PLUGINS:
             plugin_name = plugin_class.get_name()
-            plugin_config = self.db.get_config_key(plugin_name)
+            plugin_config = self.db.get_plugin_config(plugin_name)
             try:
                 active_plugins.append(plugin_class(self.db, plugin_config))
                 logging.info("Loaded %s plugin", plugin_name)

--- a/src/db.py
+++ b/src/db.py
@@ -321,10 +321,11 @@ class Database:
         }
 
     def get_core_config(self) -> Dict[str, str]:
-        """Gets a list of configuration fields for the mquery core.
-        Will be extended in future PRs. For now nothing is configurable.
-        """
-        return {}
+        """Gets a list of configuration fields for the mquery core."""
+        return {
+            "openid_auth_url": "OpenID Connect auth url",
+            "openid_login_url": "OpenID Connect login url",
+        }
 
     def get_config(self) -> List[ConfigSchema]:
         # { plugin_name: { field: description } }
@@ -347,7 +348,7 @@ class Database:
         }
         # Get configuration values for each plugin
         for plugin, spec in plugin_configs.items():
-            config = self.get_config_key(plugin)
+            config = self.get_plugin_config(plugin)
             for key, value in config.items():
                 if key in plugin_configs[plugin]:
                     plugin_configs[plugin][key].value = value
@@ -361,8 +362,11 @@ class Database:
     def get_config_version(self) -> int:
         return int(self.redis.get("plugin-version") or 0)
 
-    def get_config_key(self, plugin_name: str) -> Dict[str, str]:
+    def get_plugin_config(self, plugin_name: str) -> Dict[str, str]:
         return self.redis.hgetall(f"plugin:{plugin_name}")
+
+    def get_config_key(self, plugin_name: str, key: str) -> Optional[str]:
+        return self.redis.hget(f"plugin:{plugin_name}", key)
 
     def set_config_key(self, plugin_name: str, key: str, value: str) -> None:
         self.redis.hset(f"plugin:{plugin_name}", key, value)

--- a/src/e2etests/test_api.py
+++ b/src/e2etests/test_api.py
@@ -179,6 +179,15 @@ def test_query_with_taints(add_files_to_index):
         assert len(m) == 1
 
 
+@pytest.mark.timeout(30)
+def test_api_server_runs():
+    log = logging.getLogger()
+    res = requests.get("http://web:5000/api/server")
+    log.info("API response: %s", res.json())
+    res.raise_for_status()
+    assert "version" in res.json()
+
+
 @pytest.fixture(scope="session", autouse=True)
 def add_files_to_index(check_operational):
     num_files = 100

--- a/src/mqueryfront/src/App.js
+++ b/src/mqueryfront/src/App.js
@@ -5,12 +5,21 @@ import QueryPage from "./query/QueryPage";
 import RecentPage from "./recent/RecentPage";
 import StatusPage from "./status/StatusPage";
 import ConfigPage from "./config/ConfigPage";
+import AuthPage from "./auth/AuthPage";
 import axios from "axios";
 import { API_URL } from "./config";
 import "./App.css";
 
+function parseJWT(token) {
+    const base64Url = token.split(".")[1];
+    const base64 = base64Url.replace("-", "+").replace("_", "/");
+    return JSON.parse(Buffer.from(base64, "base64").toString("binary"));
+}
+
 function App() {
     const [config, setConfig] = useState(null);
+    const rawToken = localStorage.getItem("rawToken");
+    const token = rawToken ? parseJWT(rawToken) : null;
 
     useEffect(() => {
         axios.get(`${API_URL}/server`).then((response) => {
@@ -18,29 +27,29 @@ function App() {
         });
     }, []);
 
+    const login = (rawToken) => {
+        localStorage.setItem("rawToken", rawToken);
+        window.location.href = "/";
+    };
+
+    const logout = () => {
+        localStorage.removeItem("rawToken");
+        window.location.href = "/";
+    };
+
     return (
         <div className="App">
-            <Navigation />
+            <Navigation session={token} config={config} logout={logout} />
             <Routes>
-                <Route exact path="/" element={<QueryPage config={config} />} />
-                <Route
-                    path="/query/:hash"
-                    element={<QueryPage config={config} />}
-                />
-                <Route
-                    exact
-                    path="/recent"
-                    element={<RecentPage config={config} />}
-                />
+                <Route exact path="/" element={<QueryPage />} />
+                <Route path="/query/:hash" element={<QueryPage />} />
+                <Route exact path="/recent" element={<RecentPage />} />
+                <Route exact path="/config" element={<ConfigPage />} />
+                <Route exact path="/status" element={<StatusPage />} />
                 <Route
                     exact
-                    path="/config"
-                    element={<ConfigPage config={config} />}
-                />
-                <Route
-                    exact
-                    path="/status"
-                    element={<StatusPage config={config} />}
+                    path="/auth"
+                    element={<AuthPage config={config} login={login} />}
                 />
             </Routes>
         </div>

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -2,7 +2,28 @@ import React from "react";
 import { Link } from "react-router-dom";
 import logo from "./logo.svg";
 
-function Navigation() {
+function Navigation(props) {
+    let loginElm = null;
+    if (!props.config || !props.config["openid_login_url"]) {
+        loginElm = null;
+    } else if (props.session != null) {
+        loginElm = (
+            <li className="nav-item nav-right">
+                <a className="nav-link" href="/" onClick={props.logout}>
+                    Logout ({props.session.preferred_username})
+                </a>
+            </li>
+        );
+    } else {
+        loginElm = (
+            <li className="nav-item nav-right">
+                <a className="nav-link" href={props.config["openid_login_url"]}>
+                    Login
+                </a>
+            </li>
+        );
+    }
+
     return (
         <nav className="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
             <Link className="navbar-brand" to={"/"}>
@@ -52,6 +73,7 @@ function Navigation() {
                             API Docs
                         </a>
                     </li>
+                    {loginElm}
                 </ul>
             </div>
         </nav>

--- a/src/mqueryfront/src/auth/AuthPage.js
+++ b/src/mqueryfront/src/auth/AuthPage.js
@@ -1,0 +1,53 @@
+import React, { Component } from "react";
+import ErrorBoundary from "../components/ErrorBoundary";
+import axios from "axios";
+
+class AuthPage extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            error: null,
+        };
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.config == prevProps.config || !this.props.config) {
+            return;
+        }
+        if (!this.props.config["openid_auth_url"]) {
+            this.setState({ error: "OIDC not configured" });
+        }
+        const queryString = window.location.search;
+        const urlParams = new URLSearchParams(queryString);
+        const code = urlParams.get("code");
+
+        const params = new URLSearchParams();
+        params.append("grant_type", "authorization_code");
+        params.append("code", code);
+        params.append("client_id", "app");
+        axios
+            .post(this.props.config["openid_auth_url"], params)
+            .then((response) => {
+                this.props.login(response.data["access_token"]);
+            })
+            .catch((error) => {
+                this.setState({ error: error });
+            });
+    }
+
+    render() {
+        const message = this.state.username
+            ? `Logged in as ${JSON.stringify(this.state.username)}`
+            : "Logging in...";
+        return (
+            <ErrorBoundary error={this.state.error}>
+                <div className="container-fluid">
+                    <h1 className="text-center mq-bottom">{message}</h1>
+                </div>
+            </ErrorBoundary>
+        );
+    }
+}
+
+export default AuthPage;

--- a/src/schema.py
+++ b/src/schema.py
@@ -127,3 +127,5 @@ class BackendStatusDatasetsSchema(BaseModel):
 
 class ServerSchema(BaseModel):
     version: str
+    openid_auth_url: Optional[str]
+    openid_login_url: Optional[str]


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Users are not implemented, as per #23

**What is the new behaviour?**
There is a "login" and "logout" button on the navbar:

![image](https://user-images.githubusercontent.com/7026881/146658951-8a619858-135c-4dff-9d9e-a79f340ef83f.png)

![image](https://user-images.githubusercontent.com/7026881/146658955-edd4fd94-782a-4994-86b1-cb36d42e5136.png)

They are visible only after configuring `openid_login_url` field in the database config (so it should be safe to merge).

They actually login the user with OIDC.

**Test plan**
1. Set up mquery as usual
2. Go to keystone panel (http://localhost:8080/), create a realm `myrealm`, add a user, and create a OIDC client: 

![image](https://user-images.githubusercontent.com/7026881/146659040-72f18a49-af67-4b5d-9abf-c6b89bcb8ad4.png)

3. Go to `/config` in mquery, and set openid_auth_url to `http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token` and `openid_login_url` to `http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/auth?client_id=app&response_type=code`

**Closing issues**

WIP for #23 
