### PR TITLE
Enforce user permissions server-side

### DIFF
--- a/requirements.plain.txt
+++ b/requirements.plain.txt
@@ -8,3 +8,4 @@ uvicorn
 yara-python
 yaramod
 cachetools
+pyjwt[crypto]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ uvicorn==0.15.0
 wrapt==1.13.3
 yara-python==4.1.3
 yaramod==3.12.1
+PyJWT[crypto]==2.3.0

--- a/src/app.py
+++ b/src/app.py
@@ -113,9 +113,12 @@ class RoleChecker:
         client_id = db.get_mquery_config_key("openid_client_id")
         user_roles = user.roles(client_id)
         auth_default_roles = db.get_mquery_config_key("auth_default_roles")
-        default_roles = [
-            role.strip() for role in auth_default_roles.split(",")
-        ]
+        if auth_default_roles is None:
+            default_roles = []
+        else:
+            default_roles = [
+                role.strip() for role in auth_default_roles.split(",")
+            ]
         all_user_roles = list(set(user_roles + default_roles))
 
         if not any(role in self.allowed_roles for role in all_user_roles):

--- a/src/app.py
+++ b/src/app.py
@@ -59,8 +59,10 @@ class User:
     def roles(self, client_id: Optional[str]) -> List[str]:
         if self.__token is None:
             return []
-        access = self.__token.get("resource_access", {})
-        return access.get(client_id, {}).get("roles", [])
+        try:
+            return self.__token["resource_access"][client_id]["roles"]
+        except KeyError:
+            return []
 
 
 async def current_user(authorization: Optional[str] = Header(None)) -> User:

--- a/src/db.py
+++ b/src/db.py
@@ -323,9 +323,14 @@ class Database:
     def get_core_config(self) -> Dict[str, str]:
         """Gets a list of configuration fields for the mquery core."""
         return {
+            # Autentication-related config
+            "auth_enabled": "Enable and force authentication for all users",
+            "auth_default_roles": "Comma separated list of roles available to everyone",
+            # OpenID Authentication config
             "openid_auth_url": "OpenID Connect auth url",
             "openid_login_url": "OpenID Connect login url",
             "openid_client_id": "OpenID client ID",
+            "openid_secret": "Secret used for JWT token verification",
         }
 
     def get_config(self) -> List[ConfigSchema]:
@@ -368,6 +373,9 @@ class Database:
 
     def get_config_key(self, plugin_name: str, key: str) -> Optional[str]:
         return self.redis.hget(f"plugin:{plugin_name}", key)
+
+    def get_mquery_config_key(self, key: str) -> Optional[str]:
+        return self.redis.hget(f"plugin:{MQUERY_PLUGIN_NAME}", key)
 
     def set_config_key(self, plugin_name: str, key: str, value: str) -> None:
         self.redis.hset(f"plugin:{plugin_name}", key, value)

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -1,10 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import logo from "./logo.svg";
+import { isAuthEnabled } from "./utils";
 
 function Navigation(props) {
     let loginElm = null;
-    if (!props.config || !props.config["openid_login_url"]) {
+    let authEnabled = isAuthEnabled(props.config);
+    if (!authEnabled) {
         loginElm = null;
     } else if (props.session != null) {
         loginElm = (
@@ -17,7 +19,7 @@ function Navigation(props) {
     } else {
         loginElm = (
             <li className="nav-item nav-right">
-                <a className="nav-link" href={props.config["openid_login_url"]}>
+                <a className="nav-link" href="/auth">
                     Login
                 </a>
             </li>

--- a/src/mqueryfront/src/api.js
+++ b/src/mqueryfront/src/api.js
@@ -9,14 +9,21 @@ export function parseJWT(token) {
 }
 
 function request(method, path, payload, params) {
-    const rawToken = localStorage.getItem("token");
+    const rawToken = localStorage.getItem("rawToken");
     const headers = rawToken ? { Authorization: `Bearer ${rawToken}` } : {};
-    return axios.request(path, {
-        method: method,
-        data: payload,
-        params: params,
-        headers: headers,
-    });
+    return axios
+        .request(path, {
+            method: method,
+            data: payload,
+            params: params,
+            headers: headers,
+        })
+        .catch((error) => {
+            if (error.response.status === 401) {
+                window.location = "/auth";
+            }
+            return error;
+        });
 }
 
 function post(path, payload) {

--- a/src/mqueryfront/src/components/QueryProgressBar.js
+++ b/src/mqueryfront/src/components/QueryProgressBar.js
@@ -1,7 +1,7 @@
 import React from "react";
 import ActionCancel from "./ActionCancel";
 import QueryTimer from "./QueryTimer";
-import { isStatusFinished, getProgressBarClass } from "../queryUtils";
+import { isStatusFinished, getProgressBarClass } from "../utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 

--- a/src/mqueryfront/src/query/QueryPage.js
+++ b/src/mqueryfront/src/query/QueryPage.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import api from "../api";
-import { isStatusFinished } from "../queryUtils";
+import { isStatusFinished } from "../utils";
 import QueryLayoutManager from "./QueryLayoutManager";
 import ErrorBoundary from "../components/ErrorBoundary";
 import { useParams, useLocation, useNavigate } from "react-router-dom";

--- a/src/mqueryfront/src/query/yara-lang.js
+++ b/src/mqueryfront/src/query/yara-lang.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 const YARA = {
     TOKEN_PROVIDER: {
         defaultToken: "invalid",

--- a/src/mqueryfront/src/recent/SearchJobItem.js
+++ b/src/mqueryfront/src/recent/SearchJobItem.js
@@ -4,7 +4,7 @@ import PriorityIcon from "../components/PriorityIcon";
 import ActionRemove from "../components/ActionRemove";
 import ActionCancel from "../components/ActionCancel";
 import QueryProgressBar from "../components/QueryProgressBar";
-import { isStatusFinished } from "../queryUtils";
+import { isStatusFinished } from "../utils";
 
 export const SearchJobItemEmpty = () => {
     return (

--- a/src/mqueryfront/src/utils.js
+++ b/src/mqueryfront/src/utils.js
@@ -15,3 +15,6 @@ export const getProgressBarClass = (status) => {
     const classSufix = statusClassMap[status];
     return "progress-bar" + (classSufix ? " bg-" + classSufix : "");
 };
+
+export const isAuthEnabled = (config) =>
+    config && config["auth_enabled"] && config["auth_enabled"] !== "false";

--- a/src/schema.py
+++ b/src/schema.py
@@ -127,6 +127,7 @@ class BackendStatusDatasetsSchema(BaseModel):
 
 class ServerSchema(BaseModel):
     version: str
+    auth_enabled: str
     openid_auth_url: Optional[str]
     openid_login_url: Optional[str]
     openid_client_id: Optional[str]

--- a/src/schema.py
+++ b/src/schema.py
@@ -127,7 +127,7 @@ class BackendStatusDatasetsSchema(BaseModel):
 
 class ServerSchema(BaseModel):
     version: str
-    auth_enabled: str
+    auth_enabled: Optional[str]
     openid_auth_url: Optional[str]
     openid_login_url: Optional[str]
     openid_client_id: Optional[str]


### PR DESCRIPTION
Parse, verify, and enforce user permissions server-side.

This still has some rough edges that will be improved upon in the follow-up PRs, including at least:

- [ ] refactor the config handling
- [ ] hide UI elements that the current user has no permissions to
- [ ] add a validation logic to the config view
- [ ] (optional) improve the UI of the config view

And (possibly in the future)
- [ ] limit users only to specific tags
- [ ] hide queries done by another user from a logged in user
- [ ] allow read-only users (low-priority)

Part of #23 