### PR TITLE
Fix/config UI

### DIFF
--- a/src/mqueryfront/src/auth/AuthPage.js
+++ b/src/mqueryfront/src/auth/AuthPage.js
@@ -28,7 +28,7 @@ class AuthPage extends Component {
         if (code === null) {
             const login_url = this.props.config["openid_login_url"];
             if (!login_url) {
-                this.setState({ error: "OUDC login URL not configured" });
+                this.setState({ error: "OIDC login URL not configured" });
             } else {
                 window.location = this.props.config["openid_login_url"];
             }

--- a/src/mqueryfront/src/config/ConfigEntries.js
+++ b/src/mqueryfront/src/config/ConfigEntries.js
@@ -114,7 +114,15 @@ class ConfigRow extends Component {
                 </td>
                 <td className="w-25">
                     <div className="d-flex">
-                        <div className="flex-grow-1" style={{"word-wrap": "break-word", "max-width": "800px"}}>{valueControl}</div>
+                        <div
+                            className="flex-grow-1"
+                            style={{
+                                "word-wrap": "break-word",
+                                "max-width": "800px",
+                            }}
+                        >
+                            {valueControl}
+                        </div>
                         <div className="flex-shrink-1">{editToggle}</div>
                     </div>
                 </td>

--- a/src/mqueryfront/src/config/ConfigEntries.js
+++ b/src/mqueryfront/src/config/ConfigEntries.js
@@ -114,7 +114,7 @@ class ConfigRow extends Component {
                 </td>
                 <td className="w-25">
                     <div className="d-flex">
-                        <div className="flex-grow-1">{valueControl}</div>
+                        <div className="flex-grow-1" style={{"word-wrap": "break-word", "max-width": "800px"}}>{valueControl}</div>
                         <div className="flex-shrink-1">{editToggle}</div>
                     </div>
                 </td>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Config UI is unusable when there are long values

![image](https://user-images.githubusercontent.com/7026881/147713763-c85fdec6-1d76-491e-8da0-56f4cd1f8818.png)

**What is the new behaviour?**
There is a max field width.

![image](https://user-images.githubusercontent.com/7026881/147713771-8e5299f9-4f5c-429f-a90a-e6b81e702702.png)

Yes, I'm aware that this is a hack (max width in pixels). But after trying random things for an hour I have enough CSS for today. I have officially no idea how to fix that, and I believe the new behaviour is strictly better than the old one, hence this should be merged (and maybe improved in the future).

