### PR TITLE
Fix: Replace Buffer with atob

### DIFF
--- a/src/mqueryfront/src/api.js
+++ b/src/mqueryfront/src/api.js
@@ -5,7 +5,7 @@ export const api_url = "/api";
 export function parseJWT(token) {
     const base64Url = token.split(".")[1];
     const base64 = base64Url.replace("-", "+").replace("_", "/");
-    return JSON.parse(Buffer.from(base64, "base64").toString("binary"));
+    return JSON.parse(atob(base64));
 }
 
 function request(method, path, payload, params) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
![image](https://user-images.githubusercontent.com/8720367/159895468-3b554ed3-1837-42e5-83ed-91288dbcd99f.png)

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Replace Buffer (which is Node.js API) with atob (Web API).

**Test plan**
<!-- Explain how to test your changes -->
Check if JWT-based capabilities work OK in the browser
<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
