### PR TITLE
Improve parsing of string count expressions

### DIFF
--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -491,12 +491,14 @@ class RuleParseEngine:
         if isinstance(condition.right_operand, IntLiteralExpression):
             if condition.right_operand.value > 0:
                 return self.traverse(condition.left_operand)
+        return None
 
     def le_expr(self, condition: LeExpression) -> Optional[UrsaExpression]:
         """ From `y <= #a` we can deduce, that #a must occur at least once if y>0 """
         if isinstance(condition.left_operand, IntLiteralExpression):
             if condition.left_operand.value > 0:
                 return self.traverse(condition.right_operand)
+        return None
 
     def eq_expr(self, condition: EqExpression) -> Optional[UrsaExpression]:
         """ From `x == literal` and literal > 0 we can deduce that x must occur """

--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -499,20 +499,14 @@ class RuleParseEngine:
                 return self.traverse(condition.right_operand)
 
     def eq_expr(self, condition: EqExpression) -> Optional[UrsaExpression]:
-        """ From `x = y` we can deduce, that x and y must both occur - unless:
-            - x = 0, or y = 0
-            - both x and y are count expressions (both can be zero)
-        """
+        """ From `x == literal` and literal > 0 we can deduce that x must occur """
         if isinstance(condition.left_operand, IntLiteralExpression):
-            if isinstance(condition.right_operand, IntLiteralExpression):
-                if condition.left_operand == condition.right_operand == 0:
-                    return None
-        if isinstance(condition.left_operand, StringCountExpression):
-            if isinstance(condition.right_operand, StringCountExpression):
-                return None
-        left = self.traverse(condition.left_operand)
-        right = self.traverse(condition.right_operand)
-        return left or right
+            if condition.left_operand.value > 0:
+                return self.traverse(condition.right_operand)
+        if isinstance(condition.right_operand, IntLiteralExpression):
+            if condition.right_operand.value > 0:
+                return self.traverse(condition.left_operand)
+        return None
 
     def str_count_expr(
         self, condition: StringCountExpression

--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -492,7 +492,6 @@ class RuleParseEngine:
             if condition.right_operand.value > 0:
                 return self.traverse(condition.left_operand)
 
-
     def le_expr(self, condition: LeExpression) -> Optional[UrsaExpression]:
         """ From `y <= #a` we can deduce, that #a must occur at least once if y>0 """
         if isinstance(condition.left_operand, IntLiteralExpression):

--- a/src/tests/test_yaraparse.py
+++ b/src/tests/test_yaraparse.py
@@ -2,8 +2,7 @@
 Unit tests for yaraparse
 """
 
-from lib.yaraparse import ursify_hex
-from lib.yaraparse import ursify_plain_string
+from lib.yaraparse import ursify_hex, ursify_plain_string, parse_yara
 import yaramod
 
 
@@ -24,3 +23,97 @@ def test_literal_to_hex():
     result = ursify_plain_string(ascii_str.pure_text, is_ascii=True)
 
     assert result.query == "{616263}"
+
+
+def rule_to_query(rule):
+    result = parse_yara(rule)
+    rule, = result
+    parsed = rule.parse()
+    return parsed.query
+
+def test_condition_gt():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+        condition:
+            #x > 1
+    }""")
+    assert query == "{74657374}"
+
+
+def test_condition_lt():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+        condition:
+            1 < #x
+    }""")
+    assert query == "{74657374}"
+
+def test_condition_ge():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+        condition:
+            #x >= 1
+    }""")
+    assert query == "{74657374}"
+
+
+def test_condition_gt_reversed():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+        condition:
+            1 < #x
+    }""")
+    assert query == "{74657374}"
+
+
+def test_condition_eq():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+        condition:
+            #x == 1
+    }""")
+    assert query == "{74657374}"
+
+
+def test_condition_eq_rev():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+        condition:
+            1 == #x
+    }""")
+    assert query == "{74657374}"
+
+
+def test_condition_eq0():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+        condition:
+            #x == 0
+    }""")
+    assert query == "{74657374}"
+
+
+def test_condition_eq_syms():
+    query = rule_to_query("""
+    rule test {
+        strings:
+            $x = "test"
+            $y = "welp"
+        condition:
+            #x == #y
+    }""")
+    assert query == "{}"

--- a/src/tests/test_yaraparse.py
+++ b/src/tests/test_yaraparse.py
@@ -120,7 +120,7 @@ def test_condition_eq0():
             #x == 0
     }"""
     )
-    assert query == "{74657374}"
+    assert query == "{}"
 
 
 def test_condition_eq_syms():

--- a/src/tests/test_yaraparse.py
+++ b/src/tests/test_yaraparse.py
@@ -27,93 +27,111 @@ def test_literal_to_hex():
 
 def rule_to_query(rule):
     result = parse_yara(rule)
-    rule, = result
+    (rule,) = result
     parsed = rule.parse()
     return parsed.query
 
+
 def test_condition_gt():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
         condition:
             #x > 1
-    }""")
+    }"""
+    )
     assert query == "{74657374}"
 
 
 def test_condition_lt():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
         condition:
             1 < #x
-    }""")
+    }"""
+    )
     assert query == "{74657374}"
 
+
 def test_condition_ge():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
         condition:
             #x >= 1
-    }""")
+    }"""
+    )
     assert query == "{74657374}"
 
 
 def test_condition_gt_reversed():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
         condition:
             1 < #x
-    }""")
+    }"""
+    )
     assert query == "{74657374}"
 
 
 def test_condition_eq():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
         condition:
             #x == 1
-    }""")
+    }"""
+    )
     assert query == "{74657374}"
 
 
 def test_condition_eq_rev():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
         condition:
             1 == #x
-    }""")
+    }"""
+    )
     assert query == "{74657374}"
 
 
 def test_condition_eq0():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
         condition:
             #x == 0
-    }""")
+    }"""
+    )
     assert query == "{74657374}"
 
 
 def test_condition_eq_syms():
-    query = rule_to_query("""
+    query = rule_to_query(
+        """
     rule test {
         strings:
             $x = "test"
             $y = "welp"
         condition:
             #x == #y
-    }""")
+    }"""
+    )
     assert query == "{}"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [x] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**

The bug was discovered by running something equivalent to:
```
rule rule_name
{
    meta:
        description = "description"
        author = "author"
        date = "2022-04-05"
        reference = "reference"
        hash = "hash"
    strings:
        $name = "string"
    condition:
        #name >=3
}
```

`>=` operator was not supported well enough. I've also found many other cases of similar problems.

**What is the new behaviour?**

I fix some of the problems. There are still many ways to improve this (for example, handle `#x != 0`)

**Test plan**

I've tried to avoid any bugs, but due to the nature of the code (explicitly checking types of operators and parameters) it's bug-prone and there may be obscure combinations of operators that will be broken by this. I've taken moderate care to avoid this, but consulting https://yara.readthedocs.io/en/stable/writingrules.html for any edge cases may be helpful in review.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

Submitted privately, no github issue.