### PR TITLE
Fix #270: Finish job with several parallel daemon groups

### DIFF
--- a/src/daemon.py
+++ b/src/daemon.py
@@ -278,7 +278,7 @@ class Agent:
             and j.datasets_left == 0
         ):
             # The job is over, work of this agent as done.
-            self.db.agent_finish_job(job)
+            self.db.finish_job(job)
 
     def __process_task(self, task: AgentTask) -> None:
         """Dispatches and executes the next incoming task.

--- a/src/db.py
+++ b/src/db.py
@@ -294,6 +294,11 @@ class Database:
                 job.key, {"status": "done", "finished": int(time())}
             )
 
+    def finish_job(self, job: JobId) -> None:
+        self.redis.hmset(
+            job.key, {"status": "done", "finished": int(time())}
+        )
+
     def has_pending_search_tasks(self, agent_id: str, job: JobId) -> bool:
         return self.redis.llen(f"job-ds:{agent_id}:{job.hash}") == 0
 


### PR DESCRIPTION

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Job is never finishes if there are several daemon groups (docker-compose.yml for reproduce: https://github.com/ekorolevanyrun/parallel-ursadb/blob/main/docker-compose.yml)

**What is the new behaviour?**
The condition (https://github.com/ekorolevanyrun/mquery/blob/fix/issue_270/src/daemon.py#L275) will be truth only once when the latest daemon finishes the task.

**Test plan**
Before changes job is never finishes, after changes job finishes after the latest daemon finish the job.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #270 
