### PR TITLE
Fix OIDC logout flow

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -105,7 +105,7 @@ executing `HMSET plugin:Mquery auth_enabled ""`.
 
 ![](./new-client.png)
 
-- Edit the client, and set `Valid Redirect URIs` to `http://localhost/auth` (or `http://[mquery_url]/auth`).
+- Edit the client, and set `Valid Redirect URIs` to `http://localhost/*` (or `http://[mquery_url]/*`).
 
 - Go to the `roles` subpage **in the client**, and add `admin` and `user` roles.
 
@@ -124,9 +124,8 @@ and grant appropriate roles to the user (remember to grant yourself an admin rol
 
 Go back to the config page again (http://localhost/config).
 
-- Set `opeind_auth_url` to `http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/token`
-- Set `opeind_client_id` to `mquery` (`client id` from the step 1)
-- Set `opeind_login_url` to `http://localhost:8080/auth/realms/myrealm/protocol/openid-connect/auth?client_id=mquery&response_type=code` (change client_id if needed)
+- Set `openid_url` to `http://localhost:8080/auth/realms/myrealm/protocol/openid-connect`
+- Set `openid_client_id` to `mquery` (`client id` from the step 1)
 - Set `openid_secret` to the `RS256` public key of your realm.
 Get it from `http://localhost:8080/auth/admin/master/console/#/realms/myrealm/keys`
 (configure -> realm settings -> public key)

--- a/src/app.py
+++ b/src/app.py
@@ -83,9 +83,10 @@ async def current_user(authorization: Optional[str] = Header(None)) -> User:
             token, public_key, algorithms=["RS256"], audience="account"  # type: ignore
         )
     except jwt.ExpiredSignatureError:
-        raise HTTPException(
-            status_code=401, detail="The signature has expired",
-        )
+        # The signature has expired. Maybe we should raise 401 here, but on the
+        # other hand we don't want to raise 401 if auth_enabled is not enabled.
+        return User(None)
+
     return User(token_json)
 
 
@@ -480,8 +481,7 @@ def server() -> ServerSchema:
     return ServerSchema(
         version=mquery_version(),
         auth_enabled=db.get_mquery_config_key("auth_enabled"),
-        openid_auth_url=db.get_mquery_config_key("openid_auth_url"),
-        openid_login_url=db.get_mquery_config_key("openid_login_url"),
+        openid_url=db.get_mquery_config_key("openid_url"),
         openid_client_id=db.get_mquery_config_key("openid_client_id"),
     )
 

--- a/src/db.py
+++ b/src/db.py
@@ -327,8 +327,7 @@ class Database:
             "auth_enabled": "Enable and force authentication for all users",
             "auth_default_roles": "Comma separated list of roles available to everyone",
             # OpenID Authentication config
-            "openid_auth_url": "OpenID Connect auth url",
-            "openid_login_url": "OpenID Connect login url",
+            "openid_url": "OpenID Connect base url",
             "openid_client_id": "OpenID client ID",
             "openid_secret": "Secret used for JWT token verification",
         }

--- a/src/mqueryfront/src/App.js
+++ b/src/mqueryfront/src/App.js
@@ -27,7 +27,17 @@ function App() {
 
     const logout = () => {
         localStorage.removeItem("rawToken");
-        window.location.href = "/";
+        if (config !== null) {
+            const logout_url = new URL(config["openid_url"] + "/logout");
+            logout_url.searchParams.append(
+                "redirect_uri",
+                window.location.origin
+            );
+            window.location.href = logout_url;
+        } else {
+            // Shouldn't happen, but reload just in case.
+            window.location.href = "/";
+        }
     };
 
     return (

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -11,7 +11,7 @@ function Navigation(props) {
     } else if (props.session != null) {
         loginElm = (
             <li className="nav-item nav-right">
-                <a className="nav-link" href="/" onClick={props.logout}>
+                <a className="nav-link" href="#" onClick={props.logout}>
                     Logout ({props.session.preferred_username})
                 </a>
             </li>

--- a/src/mqueryfront/src/auth/AuthPage.js
+++ b/src/mqueryfront/src/auth/AuthPage.js
@@ -26,11 +26,23 @@ class AuthPage extends Component {
         const code = urlParams.get("code");
 
         if (code === null) {
-            const login_url = this.props.config["openid_login_url"];
+            const login_url = new URL(
+                this.props.config["openid_url"] + "/auth"
+            );
+            login_url.searchParams.append(
+                "client_id",
+                this.props.config["openid_client_id"]
+            );
+            login_url.searchParams.append("response_type", "code");
+            login_url.searchParams.append(
+                "redirect_uri",
+                window.location.origin + "/auth"
+            );
+
             if (!login_url) {
                 this.setState({ error: "OIDC login URL not configured" });
             } else {
-                window.location = this.props.config["openid_login_url"];
+                window.location = login_url;
             }
             return;
         }
@@ -39,8 +51,9 @@ class AuthPage extends Component {
         params.append("grant_type", "authorization_code");
         params.append("code", code);
         params.append("client_id", this.props.config["openid_client_id"]);
+        params.append("redirect_uri", window.location.origin + "/auth");
         axios
-            .post(this.props.config["openid_auth_url"], params)
+            .post(this.props.config["openid_url"] + "/token", params)
             .then((response) => {
                 this.props.login(response.data["access_token"]);
             })

--- a/src/schema.py
+++ b/src/schema.py
@@ -128,6 +128,5 @@ class BackendStatusDatasetsSchema(BaseModel):
 class ServerSchema(BaseModel):
     version: str
     auth_enabled: Optional[str]
-    openid_auth_url: Optional[str]
-    openid_login_url: Optional[str]
+    openid_url: Optional[str]
     openid_client_id: Optional[str]


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
It turns out OIDC is hard. Of course I already knew it when I decided to use it, but it's harder than I expected. It's not even easy to logout correctly (and I don't mean the way I do it right now is perfect).

**What is the new behaviour?**
Logout button works correctly - fixes #273. This is achieved by sending a logout request to the **whole OIDC realm**, so the user is logged out of the whole instance. This is probably what the user means by clicking the logout button ("I don't want to be logged in here anymore").

This also required a small refactoring, and exposed more areas to improve (for example, login/logout flow is very redirect heavy, and it doesn't have to).

**Test plan**
- Click login.
- Login.
- Click logout.
- Logout.
- Ensure you're still logged out.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #273
