### PR TITLE
Split ursadb and mquery repo

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,18 +42,17 @@ services:
     environment:
       - "MQUERY_PLUGINS=${MQUERY_PLUGINS}"
   ursadb:
-    build:
-      context: ursadb/
-      dockerfile: Dockerfile
+    image: mqueryci/ursadb:v1.5.0
     ports:
     - "9281:9281"
     volumes:
     - "${SAMPLES_DIR}:/mnt/samples"
     - "${INDEX_DIR}:/var/lib/ursadb"
+    user: "0:0"
   keycloak:
     image: quay.io/keycloak/keycloak:15.1.0
     ports:
-    - 8080:8080
+    - "8080:8080"
     environment:
     - KEYCLOAK_USER=admin
     - KEYCLOAK_PASSWORD=admin

--- a/docker-compose.e2etests-local.yml
+++ b/docker-compose.e2etests-local.yml
@@ -47,6 +47,7 @@ services:
     volumes:
       - "./e2e-state/samples:/mnt/samples"
       - "./e2e-state/index:/var/lib/ursadb"
+    user: "0:0"
   redis:
     restart: always
     image: redis

--- a/docker-compose.e2etests-local.yml
+++ b/docker-compose.e2etests-local.yml
@@ -39,9 +39,7 @@ services:
       - "redis"
       - "ursadb"
   ursadb:
-    build:
-      context: ursadb/
-      dockerfile: Dockerfile
+    image: mqueryci/ursadb:v1.5.0
     ports:
       - "9281:9281"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,14 +31,13 @@ services:
       - "MQUERY_PLUGINS=${MQUERY_PLUGINS}"
   ursadb:
     restart: always
-    build:
-      context: ursadb/
-      dockerfile: Dockerfile
+    image: mqueryci/ursadb:v1.5.0
     ports:
     - "127.0.0.1:9281:9281"
     volumes:
     - "${SAMPLES_DIR}:/mnt/samples"
     - "${INDEX_DIR}:/var/lib/ursadb"
+    user: "0:0"
   redis:
     restart: always
     image: redis

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,9 @@ many things in mquery.
 
 ## Advanced topics 
 
+Relevant for people who want to run mquery in production or in a bigger scale.
+
+- [Security](./security.md): Security considerations for hardening your mquery instance.
 - [Distributed mquery](./distributed.md): For users that want to run mquery on
     more than one machine.
 - [On-disk format](./ondiskformat.md): Read if you want to understand ursadb's on

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ many things in mquery.
 
 ## Advanced topics 
 
-Relevant for people who want to run mquery in production or in a bigger scale.
+Relevant for people who want to run mquery in production or on a a bigger scale.
 
 - [Security](./security.md): Security considerations for hardening your mquery instance.
 - [Distributed mquery](./distributed.md): For users that want to run mquery on

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,13 +1,13 @@
 # security
 
-## Secure deployment
+## Secure Deployment
 
 There are multiple components necessary to have a working Mquery instance.
-Some of them require a special care from a security standpoint.
+Some of them require special care from a security standpoint.
 
 ### Mquery
 
-Is a standard web application written in Python. By default, everyone has permission to do everything.
+Mquery is a standard web application written in Python. By default, everyone has permission to do everything.
 This default configuration is unsuitable for bigger organisations or public instances.
 In such cases, it's recommended to enable user accounts (see [users.md](./users.md)),
 and disallow anonymous users or at least don't give them admin rights.
@@ -18,8 +18,8 @@ No special considerations.
 
 ### Redis
 
-Mquery web and daemon should have network access to redis. No other access to
-the redis database is necessary. There is no support for securing Redis with a password in the current version, so network isolation is the only way to
+Mquery web and daemon should have network access to Redis. No other access to
+the Redis database is necessary. There is no support for securing Redis with a password in the current version, so network isolation is the only way to
 prevent attacks. Most importantly, Redis must not be available from the
 public network.
 
@@ -30,15 +30,15 @@ Similarly to Redis, it's best to restrict network access to the ursadb instance.
 unauthenticated users can, for example, remove indexed data from the database,
 or cause a denial of service.
 
-In the provided docker-compose files, ursadb user is overriden to root by
+In the provided docker-compose files, the ursadb user is overridden to root by
 default. This is for
 backwards compatibility, and to simplify deployment. For production instances
-consider running ursadb with the default user (ursa, UID 1000). This means
+consider running ursadb with the default user (`ursa`, UID 1000). This means
 that the shared index volume must be writable by UID 1000, and samples must
 be readable by UID 1000.
 
 ## How to report a vulnerability
 
 There is no dedicated email for reporting a security vulnerability. Please reach out
-to cert@cert.pl, or one of the maintainers directly. If the vulnerability is not
-critical, best way to report is via a Github issue.
+to cert@cert.pl or one of the maintainers directly. If the vulnerability is not
+critical, the best way to report is via a GitHub issue.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,44 @@
+# security
+
+## Secure deployment
+
+There are multiple components necessary to have a working Mquery instance.
+Some of them require a special care from a security standpoint.
+
+### Mquery
+
+Is a standard web application written in Python. By default, everyone has permission to do everything.
+This default configuration is unsuitable for bigger organisations or public instances.
+In such cases, it's recommended to enable user accounts (see [users.md](./users.md)),
+and disallow anonymous users or at least don't give them admin rights.
+
+### Mquery daemon (agent)
+
+No special considerations.
+
+### Redis
+
+Mquery web and daemon should have network access to redis. No other access to
+the redis database is necessary. There is no support for securing Redis with a password in the current version, so network isolation is the only way to
+prevent attacks. Most importantly, Redis must not be available from the
+public network.
+
+### Ursadb
+
+Mquery daemons must have network access to their respective ursadb instances.
+Similarly to Redis, it's best to restrict network access to the ursadb instance. Ursadb protocol does not take malicious actors into account, and
+unauthenticated users can, for example, remove indexed data from the database,
+or cause a denial of service.
+
+In the provided docker-compose files, ursadb user is overriden to root by
+default. This is for
+backwards compatibility, and to simplify deployment. For production instances
+consider running ursadb with the default user (ursa, UID 1000). This means
+that the shared index volume must be writable by UID 1000, and samples must
+be readable by UID 1000.
+
+## How to report a vulnerability
+
+There is no dedicated email for reporting a security vulnerability. Please reach out
+to cert@cert.pl, or one of the maintainers directly. If the vulnerability is not
+critical, best way to report is via a Github issue.


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable) (TODO)

**What is the current behaviour?**
Mquery and ursadb shared a repo since their inception - ursadb being a submodule in the parent's repo. At this point though, most of the mquery users probably don't care about the flexibility that provides, and would benefit from a clearer separation. The only reason ursadb has for being a submodule currently is because it's being built in the mquery's docker compose. But it doesn't have to be - we push images to dockerhub, so we can just change build to upstream image.

**What is the new behaviour?**
Ursadb submodule is removed. Docker-compose files use dockerhub image references instead (`mqueryci/ursadb`).

To keep backward compatibility, I had to overwrite userid to root (ursadb's user recently changed to `ursa`). TODO: document why users may benefit from running ursadb as restricted user, and how to migrate.

**Test plan**
No testable changes - everything should "just work" as before.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #236
