### PR TITLE
Hide elements inaccessible to the current user

### DIFF
--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -6,9 +6,13 @@ import { isAuthEnabled } from "./utils";
 function Navigation(props) {
     let loginElm = null;
     let authEnabled = isAuthEnabled(props.config);
+    let isAdmin = false;
     if (!authEnabled) {
         loginElm = null;
     } else if (props.session != null) {
+        const clientId = props.config["openid_client_id"];
+        const userRoles = props.session["resource_access"][clientId]["roles"];
+        isAdmin = userRoles.includes("admin");
         loginElm = (
             <li className="nav-item nav-right">
                 <a className="nav-link" href="/" onClick={props.logout}>
@@ -58,16 +62,20 @@ function Navigation(props) {
                             Recent jobs
                         </Link>
                     </li>
-                    <li className="nav-item">
-                        <Link className="nav-link" to={"/config"}>
-                            Config
-                        </Link>
-                    </li>
-                    <li className="nav-item">
-                        <Link className="nav-link" to={"/status"}>
-                            Status
-                        </Link>
-                    </li>
+                    {isAdmin ? (
+                        <li className="nav-item">
+                            <Link className="nav-link" to={"/config"}>
+                                Config
+                            </Link>
+                        </li>
+                    ) : null}
+                    {isAdmin ? (
+                        <li className="nav-item">
+                            <Link className="nav-link" to={"/status"}>
+                                Status
+                            </Link>
+                        </li>
+                    ) : null}
                 </ul>
                 <ul className="navbar-nav navbar-right">
                     <li className="nav-item nav-right">


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)`
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
User can see all elements of the navbar, but clicking them may cause redirect to login page

**What is the new behaviour?**
Admin-only elements are hidden from non-admin users.

**Test plan**
Ensure that mquery looks like this:

for non-admin:
![image](https://user-images.githubusercontent.com/7026881/187323219-3c619776-a100-4874-962e-1170e2b28f27.png)

for admin:
![image](https://user-images.githubusercontent.com/7026881/187323274-3245c4bb-faf7-4f58-b881-0532eec18b72.png)


<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #258
