### PR TITLE
Make admin elements visible by default again

### DIFF
--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -8,7 +8,7 @@ function Navigation(props) {
     let authEnabled = isAuthEnabled(props.config);
     let isAdmin = false;
     if (!authEnabled) {
-        isAdmin = true;  // Auth is disabled - everyone is an admin.
+        isAdmin = true; // Auth is disabled - everyone is an admin.
         loginElm = null;
     } else if (props.session != null) {
         const clientId = props.config["openid_client_id"];

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -8,6 +8,7 @@ function Navigation(props) {
     let authEnabled = isAuthEnabled(props.config);
     let isAdmin = false;
     if (!authEnabled) {
+        isAdmin = true;  // Auth is disabled - everyone is an admin.
         loginElm = null;
     } else if (props.session != null) {
         const clientId = props.config["openid_client_id"];


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
I've introduced a small regression - when authentication is disabled, admin elements are hidden.

**What is the new behaviour?**
Users are treated as an admin when auth is disabled again.
