### PR TITLE
Automatically run filter plugins on all downloaded files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,6 +26,8 @@ services:
     depends_on:
       - "redis"
       - "ursadb"
+    environment:
+      - "MQUERY_PLUGINS=${MQUERY_PLUGINS}"
   dev-daemon:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     depends_on:
       - "redis"
       - "ursadb"
+    environment:
+      - "MQUERY_PLUGINS=${MQUERY_PLUGINS}"
   daemon:
     restart: always
     build:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -30,7 +30,7 @@ plugin, but to load your own plugin you need to create your own image.
 ## Filter plugins
 
 Filter plugins can be used to discard files quickly (before even running
-yara rules), or to process raw paths returned from Ursadb.
+yara rules), or to process paths returned from Ursadb.
 
 The very simple example of a filter plugin is
 [RegexBlacklistPlugin](https://github.com/CERT-Polska/mquery/tree/master/src/plugins/blacklist.py)
@@ -89,12 +89,18 @@ class GzipPlugin(MetadataPlugin):
 The same method can be used to, for example, automatically download and extract
 files from s3 automatically.
 
-One caveat worth calling out:
-Filter plugins are first executed in the context of daemon (when matching files),
-and later in the context of the web application (when downloading files from the UI).
-It's important that the set of filter plugins is the same in both cases.
-For example this means that all daemons must have the same plugins active.
-In most deployments this difference is not significant.
+Filter plugins are ran before yara matching, and before file downloads. To avoid
+unexpected behaviour, the same set of plugins should be active in the web UI and
+in the daemon.
+
+**Warning:** if you have multiple backends either ensure that all backends and the web
+frontend use the same set of plugins, or be very careful about how they interact.
+
+For example, imagine that of the backends does gzip decompression and the other doesn't.
+Without any filter plugins installed on the frontend, download results will contain a
+mix of compressed and uncompressed files. Right now the answer to this is to write a
+plugin that does conditional decompression depending on which backend a file came from.
+It's not handled automatically.
 
 ## Metadata plugins
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -89,6 +89,13 @@ class GzipPlugin(MetadataPlugin):
 The same method can be used to, for example, automatically download and extract
 files from s3 automatically.
 
+One caveat worth calling out:
+Filter plugins are first executed in the context of daemon (when matching files),
+and later in the context of the web application (when downloading files from the UI).
+It's important that the set of filter plugins is the same in both cases.
+For example this means that all daemons must have the same plugins active.
+In most deployments this difference is not significant.
+
 ## Metadata plugins
 
 Metadata plugins are used to enrich results with additional metadata.

--- a/src/app.py
+++ b/src/app.py
@@ -55,7 +55,7 @@ plugin_lock = Lock()
 
 
 def use_plugins(background: BackgroundTasks) -> None:
-    """ Acquires a plugin_lock, and releases it after cleanup and returning a response.
+    """Acquires a plugin_lock, and releases it after cleanup and returning a response.
     This function should be called by every API endpoint that uses plugins.
 
     This lock is necessary, because nothing in the plugins API makes it obvious that
@@ -260,7 +260,10 @@ def download(job_id: str, ordinal: int, file_path: str) -> Response:
             "Unexpected: trying to download a file excluded by filters"
         )
 
-    return FileResponse(final_path, filename=attach_name + ext + "_",)
+    return FileResponse(
+        final_path,
+        filename=attach_name + ext + "_",
+    )
 
 
 @app.get("/api/download/hashes/{hash}", dependencies=[Depends(is_user)])

--- a/src/app.py
+++ b/src/app.py
@@ -221,10 +221,7 @@ def download(job_id: str, ordinal: int, file_path: str) -> Response:
 
     attach_name, ext = os.path.splitext(os.path.basename(file_path))
     file_path = plugins.filter(file_path)
-    return FileResponse(
-        file_path,
-        filename=attach_name + ext + "_",
-    )
+    return FileResponse(file_path, filename=attach_name + ext + "_",)
 
 
 @app.get("/api/download/hashes/{hash}", dependencies=[Depends(is_user)])

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,15 @@ from threading import Lock
 
 import uvicorn  # type: ignore
 import config
-from fastapi import FastAPI, Body, Query, HTTPException, Depends, Header, BackgroundTasks  # type: ignore
+from fastapi import (
+    FastAPI,
+    Body,
+    Query,
+    HTTPException,
+    Depends,
+    Header,
+    BackgroundTasks,
+)  # type: ignore
 from starlette.requests import Request  # type: ignore
 from starlette.responses import Response, FileResponse, StreamingResponse  # type: ignore
 from starlette.staticfiles import StaticFiles  # type: ignore
@@ -53,6 +61,7 @@ def use_plugins(background: BackgroundTasks) -> None:
     This lock is necessary, because nothing in the plugins API makes it obvious that
     they should be thread-safe - so we assume that they're not.
     """
+
     def release_and_cleanup():
         try:
             # Hopefully this won't crash...
@@ -227,7 +236,11 @@ def config_edit(data: RequestConfigEdit = Body(...)) -> StatusSchema:
 # Accessible for every logged in user (permission: "reader")
 
 
-@app.get("/api/download", tags=["stable"], dependencies=[Depends(is_user), Depends(use_plugins)])
+@app.get(
+    "/api/download",
+    tags=["stable"],
+    dependencies=[Depends(is_user), Depends(use_plugins)],
+)
 def download(job_id: str, ordinal: int, file_path: str) -> Response:
     """
     Sends a file from given `file_path`. This path should come from
@@ -276,7 +289,10 @@ def zip_files(matches: List[Dict[Any, Any]]) -> Iterable[bytes]:
             yield reader.read()
 
 
-@app.get("/api/download/files/{hash}", dependencies=[Depends(is_user), Depends(use_plugins)])
+@app.get(
+    "/api/download/files/{hash}",
+    dependencies=[Depends(is_user), Depends(use_plugins)],
+)
 async def download_files(hash: str) -> StreamingResponse:
     matches = db.get_job_matches(JobId(hash)).matches
     return StreamingResponse(zip_files(matches))

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -183,8 +183,8 @@ class Agent:
         num_files = len(files)
         self.db.job_start_work(job, num_files)
 
-        filemap = {name: self.plugins.filter(name) for name in files}
-        filemap = {k: v for k, v in filemap.items() if v}
+        filemap_raw = {name: self.plugins.filter(name) for name in files}
+        filemap = {k: v for k, v in filemap_raw.items() if v}
 
         for orig_name, path in filemap.items():
             try:

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -10,7 +10,7 @@ from typing import Any, List
 from lib.yaraparse import parse_yara, combine_rules
 from db import AgentTask, JobId, Database, MatchInfo, TaskType
 from cachetools import cached, LRUCache  # type: ignore
-from metadata import MetadataPlugin, Metadata
+from metadata import Metadata
 from plugins import PluginManager
 
 

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -20,43 +20,47 @@ const copyHashesToClipboard = async (qhash) => {
 const DownloadDropdown = (props) => {
     const [show, setShow] = useState(false);
 
-    return <div className="dropdown">
-        <button
-            type="button"
-            className="btn shadow-none text-secondary dropdown-toggle"
-            data-toggle="dropdown"
-            onClick={() => setShow(!show)}
-        >
-            <FontAwesomeIcon icon={faDownload} size="sm" />
-        </button>
-        <div className={"dropdown-menu " + (show ? "show" : "")}>
-            <a
-                className="dropdown-item"
-                download={`${props.qhash}.zip`}
-                href={`${api_url}/download/files/${props.qhash}`}
-            >
-                <FontAwesomeIcon icon={faFileDownload} />
-                <span className="ml-3">Download files (.zip)</span>
-            </a>
-            <a
-                className="dropdown-item"
-                download={`${props.qhash}_sha256.txt`}
-                href={`${api_url}/download/hashes/${props.qhash}`}
-            >
-                <FontAwesomeIcon icon={faFileArchive} />
-                <span className="ml-3">Download sha256 hashes (.txt)</span>
-            </a>
+    return (
+        <div className="dropdown">
             <button
-                className="dropdown-item btn"
-                onClick={() => {
-                    copyHashesToClipboard(props.qhash);
-                }}
+                type="button"
+                className="btn shadow-none text-secondary dropdown-toggle"
+                data-toggle="dropdown"
+                onClick={() => setShow(!show)}
             >
-                <FontAwesomeIcon icon={faCopy} />
-                <span className="ml-3">Copy sha256 hashes to clipboard</span>
+                <FontAwesomeIcon icon={faDownload} size="sm" />
             </button>
+            <div className={"dropdown-menu " + (show ? "show" : "")}>
+                <a
+                    className="dropdown-item"
+                    download={`${props.qhash}.zip`}
+                    href={`${api_url}/download/files/${props.qhash}`}
+                >
+                    <FontAwesomeIcon icon={faFileDownload} />
+                    <span className="ml-3">Download files (.zip)</span>
+                </a>
+                <a
+                    className="dropdown-item"
+                    download={`${props.qhash}_sha256.txt`}
+                    href={`${api_url}/download/hashes/${props.qhash}`}
+                >
+                    <FontAwesomeIcon icon={faFileArchive} />
+                    <span className="ml-3">Download sha256 hashes (.txt)</span>
+                </a>
+                <button
+                    className="dropdown-item btn"
+                    onClick={() => {
+                        copyHashesToClipboard(props.qhash);
+                    }}
+                >
+                    <FontAwesomeIcon icon={faCopy} />
+                    <span className="ml-3">
+                        Copy sha256 hashes to clipboard
+                    </span>
+                </button>
+            </div>
         </div>
-    </div>
+    );
 };
 
 const QueryMatches = (props) => {

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -17,16 +17,19 @@ const copyHashesToClipboard = async (qhash) => {
     });
 };
 
-const DownloadDropdown = (props) => (
-    <div className="dropdown">
+const DownloadDropdown = (props) => {
+    const [show, setShow] = useState(false);
+
+    return <div className="dropdown">
         <button
             type="button"
             className="btn shadow-none text-secondary dropdown-toggle"
             data-toggle="dropdown"
+            onClick={() => setShow(!show)}
         >
             <FontAwesomeIcon icon={faDownload} size="sm" />
         </button>
-        <div className="dropdown-menu">
+        <div className={"dropdown-menu " + (show ? "show" : "")}>
             <a
                 className="dropdown-item"
                 download={`${props.qhash}.zip`}
@@ -54,7 +57,7 @@ const DownloadDropdown = (props) => (
             </button>
         </div>
     </div>
-);
+};
 
 const QueryMatches = (props) => {
     const { matches, qhash, pagination } = props;

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,6 +1,8 @@
-from typing import List, Type
+from typing import List, Type, Optional
 from metadata import MetadataPlugin
 from importlib import import_module
+from db import Database
+import logging
 
 
 def parse_plugin_list(plugins: str) -> List[str]:
@@ -33,3 +35,34 @@ def load_plugins(specs: List[str]) -> List[Type[MetadataPlugin]]:
         moduleobj = import_module(module)
         result.append(getattr(moduleobj, classname))
     return result
+
+
+class PluginManager():
+    def __init__(self, specs: List[str], db: Database) -> None:
+        self.plugin_classes = load_plugins(specs)
+
+        active_plugins = []
+        for plugin_class in self.plugin_classes:
+            plugin_name = plugin_class.get_name()
+            plugin_config = db.get_plugin_config(plugin_name)
+            try:
+                active_plugins.append(plugin_class(db, plugin_config))
+                logging.info("Loaded plugin %s", plugin_name)
+            except Exception:
+                logging.exception("Failed to load %s plugin", plugin_name)
+        self.active_plugins = active_plugins
+
+    def filter(self, orig_name: str) -> Optional[str]:
+        """ Runs all available filter plugins on the provided file.
+        Returns new file path, or None. User should call cleanup() later. """
+        current_path = orig_name
+        for plugin in self.active_plugins:
+            if not plugin.is_filter:
+                continue
+            if current_path:
+                current_path = plugin.filter(orig_name, current_path)
+        return current_path
+
+    def cleanup(self) -> None:
+        for plugin in self.active_plugins:
+            plugin.cleanup()

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -53,8 +53,8 @@ class PluginManager:
         self.active_plugins = active_plugins
 
     def filter(self, orig_name: str) -> Optional[str]:
-        """ Runs all available filter plugins on the provided file.
-        Returns new file path, or None. User should call cleanup() later. """
+        """Runs all available filter plugins on the provided file.
+        Returns new file path, or None. User should call cleanup() later."""
         current_path = orig_name
         for plugin in self.active_plugins:
             if not plugin.is_filter:
@@ -69,8 +69,8 @@ class PluginManager:
         return current_path
 
     def cleanup(self) -> None:
-        """ Clean up all plugin state. Worth stressing that plugins are *not* thread
+        """Clean up all plugin state. Worth stressing that plugins are *not* thread
         safe, and running filter() and cleanup() from different threads will cause
-        problems. Running a plugin multiple times before the cleanup should be ok. """
+        problems. Running a plugin multiple times before the cleanup should be ok."""
         for plugin in self.active_plugins:
             plugin.cleanup()

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -37,7 +37,7 @@ def load_plugins(specs: List[str]) -> List[Type[MetadataPlugin]]:
     return result
 
 
-class PluginManager():
+class PluginManager:
     def __init__(self, specs: List[str], db: Database) -> None:
         self.plugin_classes = load_plugins(specs)
 

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -55,7 +55,7 @@ class PluginManager:
     def filter(self, orig_name: str) -> Optional[str]:
         """ Runs all available filter plugins on the provided file.
         Returns new file path, or None. User should call cleanup() later. """
-        current_path = orig_name
+        current_path: Optional[str] = orig_name
         for plugin in self.active_plugins:
             if not plugin.is_filter:
                 continue

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -55,14 +55,22 @@ class PluginManager:
     def filter(self, orig_name: str) -> Optional[str]:
         """ Runs all available filter plugins on the provided file.
         Returns new file path, or None. User should call cleanup() later. """
-        current_path: Optional[str] = orig_name
+        current_path = orig_name
         for plugin in self.active_plugins:
             if not plugin.is_filter:
                 continue
-            if current_path:
-                current_path = plugin.filter(orig_name, current_path)
+
+            new_path = plugin.filter(orig_name, current_path)
+            if not new_path:
+                return None
+
+            current_path = new_path
+
         return current_path
 
     def cleanup(self) -> None:
+        """ Clean up all plugin state. Worth stressing that plugins are *not* thread
+        safe, and running filter() and cleanup() from different threads will cause
+        problems. Running a plugin multiple times before the cleanup should be ok. """
         for plugin in self.active_plugins:
             plugin.cleanup()

--- a/src/plugins/archive.py
+++ b/src/plugins/archive.py
@@ -19,9 +19,9 @@ class GzipPlugin(MetadataPlugin):
         self.tmpfiles: List[IO[bytes]] = []
 
     def filter(self, orig_name: str, file_path: str) -> Optional[str]:
-        tmp = tempfile.NamedTemporaryFile()
-        self.tmpfiles.append(tmp)
         if orig_name.endswith(".gz"):
+            tmp = tempfile.NamedTemporaryFile()
+            self.tmpfiles.append(tmp)
             with gzip.open(file_path, "rb") as f_in:
                 with open(tmp.name, "wb") as f_out:
                     shutil.copyfileobj(f_in, f_out)


### PR DESCRIPTION
This is a draft PR that fixes #281. There are some minor things missing, most importantly:
 - [x] document and/or explain the limitations
 - [x] add the cleanup code (without introducing race conditions)

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Filter plugins are not exeuted when downloading files

**What is the new behaviour?**
Filter plugins are applied to downloaded files

**Test plan**
- enable archive plugin (`MQUERY_PLUGINS=plugins.archive:GzipPlugin`)
- index a .gz file
- run any query and download the file (it should be decompressed on the fly)

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #281
