### PR TITLE
Add a very basic validation to mquery config

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -169,7 +169,7 @@ def config_list() -> List[ConfigSchema]:
 def compact_files() -> StatusSchema:
     """
     Broadcasts compact command to all ursadb instances. This uses `compact all;`
-    subcommand (which is more intuitive because it ways compacts), except the
+    subcommand (which is more intuitive because it always compacts), instead of the
     recommended `compact smart;` which ignores useless merges. Because of this,
     and also because of lack of control, this it's not recommended for advanced
     users - see documentation and `compactall.py` script to learn more.
@@ -222,6 +222,8 @@ def download(job_id: str, ordinal: int, file_path: str) -> Response:
 
 @app.get("/api/download/hashes/{hash}", dependencies=[Depends(is_user)])
 def download_hashes(hash: str) -> Response:
+    """ Returns a list of job matches as a sha256 strings joined with newlines """
+
     hashes = "\n".join(
         d["meta"]["sha256"]["display_text"]
         for d in db.get_job_matches(JobId(hash)).matches

--- a/src/mqueryfront/src/config/ConfigEntries.js
+++ b/src/mqueryfront/src/config/ConfigEntries.js
@@ -6,13 +6,11 @@ const R_BOOL = /^(|true|false)$/;
 const R_URL = /^(https?:\/\/.*)$/;
 const R_ROLES = /^((admin|user)(,(admin|user))*)?$/;
 
-
 const KNOWN_RULES = {
-    "openid_url": R_URL,
-    "auth_enabled": R_BOOL,
-    "auth_default_roles": R_ROLES
-}
-
+    openid_url: R_URL,
+    auth_enabled: R_BOOL,
+    auth_default_roles: R_ROLES,
+};
 
 class ConfigRow extends Component {
     constructor(props) {
@@ -139,8 +137,8 @@ class ConfigRow extends Component {
                         <div
                             className="flex-grow-1"
                             style={{
-                                "wordWrap": "break-word",
-                                "maxWidth": "800px",
+                                wordWrap: "break-word",
+                                maxWidth: "800px",
                             }}
                         >
                             {valueControl}

--- a/src/mqueryfront/src/config/ConfigEntries.js
+++ b/src/mqueryfront/src/config/ConfigEntries.js
@@ -2,6 +2,18 @@ import React, { Component } from "react";
 import ErrorBoundary from "../components/ErrorBoundary";
 import api from "../api";
 
+const R_BOOL = /^(|true|false)$/;
+const R_URL = /^(https?:\/\/.*)$/;
+const R_ROLES = /^((admin|user)(,(admin|user))*)?$/;
+
+
+const KNOWN_RULES = {
+    "openid_url": R_URL,
+    "auth_enabled": R_BOOL,
+    "auth_default_roles": R_ROLES
+}
+
+
 class ConfigRow extends Component {
     constructor(props) {
         super(props);
@@ -47,10 +59,19 @@ class ConfigRow extends Component {
         });
     }
 
+    validate() {
+        if (this.props.keyName in KNOWN_RULES) {
+            const rule = KNOWN_RULES[this.props.keyName];
+            return rule.test(this.state.value);
+        }
+        return true;
+    }
+
     render() {
         let valueControl;
         let editToggle;
         if (this.state.edit) {
+            const isValid = this.validate();
             valueControl = (
                 <input
                     type="text"
@@ -68,6 +89,7 @@ class ConfigRow extends Component {
                         data-toggle="tooltip"
                         title="Save your changes"
                         onClick={this.save}
+                        disabled={!isValid}
                     >
                         save
                     </button>
@@ -117,8 +139,8 @@ class ConfigRow extends Component {
                         <div
                             className="flex-grow-1"
                             style={{
-                                "word-wrap": "break-word",
-                                "max-width": "800px",
+                                "wordWrap": "break-word",
+                                "maxWidth": "800px",
                             }}
                         >
                             {valueControl}


### PR DESCRIPTION

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional) - no, because there are no frontend tests yet
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
No frontend validation for config values

**What is the new behaviour?**
There is a very basic and frontend-only validation for config values. This is not a perfect solution, but may save some troubles in the first version.

