### PR TITLE
Fix/token catch

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -66,6 +66,10 @@ class User:
 
 
 async def current_user(authorization: Optional[str] = Header(None)) -> User:
+    auth_enabled = db.get_mquery_config_key("auth_enabled")
+    if not auth_enabled or auth_enabled == "false":
+        return User(None)
+
     if not authorization:
         return User(None)
 
@@ -82,8 +86,8 @@ async def current_user(authorization: Optional[str] = Header(None)) -> User:
         token_json = jwt.decode(
             token, public_key, algorithms=["RS256"], audience="account"  # type: ignore
         )
-    except jwt.ExpiredSignatureError:
-        # The signature has expired. Maybe we should raise 401 here, but on the
+    except jwt.InvalidTokenError:
+        # A generic signature error. Maybe we should raise 401 here, but on the
         # other hand we don't want to raise 401 if auth_enabled is not enabled.
         return User(None)
 


### PR DESCRIPTION
**What is the current behaviour?**

Currently it's possible to encounter problems when authentication is misconfigured, but disabled.

**What is the new behaviour?**
This PR should fix this, by early-exitting auth code when auth is disabled.

It introduces a small performance penalty, by reading auth_enabled redis key every request. At some point in future we should probably cache config per request.

**Test plan**
Ideally, run mquery, enable auth, make sure it works, disable auth, corrupt the keys and ensure mquery still works.
Otherwise, run mquery, set auth values (except auth_enable) to garbage and ensure it still works.
Finally, you can just trust me I tested it :^)

**Closing issues**

fixes #291
