### PR TITLE
Fix CSS broken by the dependency update

### DIFF
--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -52,7 +52,7 @@ function Navigation(props) {
                 className="collapse navbar-collapse"
                 id="navbarSupportedContent"
             >
-                <ul className="navbar-nav mr-auto">
+                <ul className="navbar-nav me-auto">
                     <li className="nav-item">
                         <Link className="nav-link" to={"/"}>
                             Query

--- a/src/mqueryfront/src/components/FilteringThead.js
+++ b/src/mqueryfront/src/components/FilteringThead.js
@@ -11,7 +11,7 @@ const FilteringThead = (props) => {
     ) {
         activeColumn = true;
         icon = (
-            <span className="mr-1">
+            <span className="me-1">
                 <FilterIcon tooltipMessage="active filter" />
             </span>
         );

--- a/src/mqueryfront/src/components/LoadingPage.js
+++ b/src/mqueryfront/src/components/LoadingPage.js
@@ -4,7 +4,7 @@ import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 
 const LoadingPage = () => (
     <h2>
-        <FontAwesomeIcon icon={faSpinner} spin size="lg" className="mr-2" />
+        <FontAwesomeIcon icon={faSpinner} spin size="lg" className="me-2" />
         Loading...
     </h2>
 );

--- a/src/mqueryfront/src/components/QueryProgressBar.js
+++ b/src/mqueryfront/src/components/QueryProgressBar.js
@@ -80,7 +80,7 @@ const QueryProgressBar = (props) => {
                             icon={faSpinner}
                             spin
                             size={props.size}
-                            className="mr-1"
+                            className="me-1"
                         />
                     )}
                     {statusInfo || matches}

--- a/src/mqueryfront/src/query/QueryLayoutManager.js
+++ b/src/mqueryfront/src/query/QueryLayoutManager.js
@@ -39,7 +39,7 @@ const QueryLayoutManager = (props) => {
         <div>
             <button
                 type="button"
-                className="btn btn-primary btn-sm pull-left mr-4"
+                className="btn btn-primary btn-sm pull-left me-4"
                 onClick={onCollapsePane}
             >
                 <FontAwesomeIcon icon={faAlignLeft} />

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -37,7 +37,7 @@ const DownloadDropdown = (props) => {
                     href={`${api_url}/download/files/${props.qhash}`}
                 >
                     <FontAwesomeIcon icon={faFileDownload} />
-                    <span className="ml-3">Download files (.zip)</span>
+                    <span className="ms-3">Download files (.zip)</span>
                 </a>
                 <a
                     className="dropdown-item"
@@ -45,7 +45,7 @@ const DownloadDropdown = (props) => {
                     href={`${api_url}/download/hashes/${props.qhash}`}
                 >
                     <FontAwesomeIcon icon={faFileArchive} />
-                    <span className="ml-3">Download sha256 hashes (.txt)</span>
+                    <span className="ms-3">Download sha256 hashes (.txt)</span>
                 </a>
                 <button
                     className="dropdown-item btn"
@@ -54,7 +54,7 @@ const DownloadDropdown = (props) => {
                     }}
                 >
                     <FontAwesomeIcon icon={faCopy} />
-                    <span className="ml-3">
+                    <span className="ms-3">
                         Copy sha256 hashes to clipboard
                     </span>
                 </button>
@@ -113,7 +113,7 @@ const QueryMatches = (props) => {
     const filtersHead = filters.map((v) => (
         <span
             key={v}
-            className="badge badge-pill badge-secondary ml-1 mt-1 cursor-pointer"
+            className="badge rounded-pill bg-secondary ms-1 mt-1 cursor-pointer"
             onClick={() => updateFilter(v)}
         >
             {v}
@@ -130,7 +130,7 @@ const QueryMatches = (props) => {
                     <tr>
                         <th className="col-md-8">
                             Matches
-                            <span className="d-inline-block ml-4">
+                            <span className="d-inline-block ms-4">
                                 <DownloadDropdown qhash={qhash} />
                             </span>
                             {filters.length > 0 && (

--- a/src/mqueryfront/src/query/QueryMatchesItem.js
+++ b/src/mqueryfront/src/query/QueryMatchesItem.js
@@ -13,7 +13,7 @@ const QueryMatchesItem = (props) => {
         .filter((v) => !v.hidden)
         .map((v) => (
             <a href={v.url} key={v}>
-                <span className="badge badge-pill badge-warning ml-1 mt-1">
+                <span className="badge rounded-pill bg-warning ms-1 mt-1">
                     {v.display_text}
                 </span>
             </a>
@@ -22,7 +22,7 @@ const QueryMatchesItem = (props) => {
     const matchBadges = Object.values(matches).map((v) => (
         <span
             key={v}
-            className="badge badge-pill badge-primary ml-1 mt-1 cursor-pointer"
+            className="badge rounded-pill bg-primary ms-1 mt-1 cursor-pointer"
             onClick={() => props.changeFilter(v)}
         >
             {v}
@@ -58,7 +58,7 @@ const QueryMatchesItem = (props) => {
                             {fileBasename}
                         </small>
                     </div>
-                    <small className="text-secondary ml-2 mr-1 mt-1">
+                    <small className="text-secondary ms-2 me-1 mt-1">
                         <ActionCopyToClipboard
                             text={fileBasename}
                             tooltipMessage="Copy file name to clipboard"

--- a/src/mqueryfront/src/query/QueryParseStatus.js
+++ b/src/mqueryfront/src/query/QueryParseStatus.js
@@ -19,7 +19,7 @@ const QueryParseStatus = (props) => {
             <div key={rule_name} className="mt-3">
                 <div className="form-group">
                     <label>
-                        <span className="mr-2 font-weight-bold">
+                        <span className="me-2 font-weight-bold">
                             {rule_name}
                         </span>
                         {badge}

--- a/src/mqueryfront/src/recent/SearchJobItem.js
+++ b/src/mqueryfront/src/recent/SearchJobItem.js
@@ -53,7 +53,7 @@ const SearchJobItem = (props) => {
                             {rule_name}
                         </Link>
                     </div>
-                    <span className="ml-2">
+                    <span className="ms-2">
                         <PriorityIcon priority={priority} size="1x" />
                     </span>
                 </div>

--- a/src/mqueryfront/src/status/BackendStatus.js
+++ b/src/mqueryfront/src/status/BackendStatus.js
@@ -71,6 +71,7 @@ class BackendStatus extends Component {
                 alive={agent.alive}
                 tasks={agent.tasks}
                 url={agent.url}
+                key={agent.name}
             />
         ));
 

--- a/src/mqueryfront/src/status/DatabaseTopology.js
+++ b/src/mqueryfront/src/status/DatabaseTopology.js
@@ -8,18 +8,17 @@ class DatasetRow extends Component {
     render() {
         return [
             <tr
-                data-toggle="collapse"
-                data-target={"#collapsed_" + this.props.id}
+                data-bs-toggle="collapse"
+                data-bs-target={"#collapsed_" + this.props.id}
                 className="accordion-toggle"
+                key={`hdr_${this.props.id}`}
             >
                 <td>
                     <code>{this.props.id}</code>
                     {this.props.taints.map((taint) => (
-                        <span>
+                        <span key={taint}>
                             {" "}
-                            <span className="badge badge-secondary">
-                                {taint}
-                            </span>
+                            <span className="badge bg-secondary">{taint}</span>
                         </span>
                     ))}
                 </td>
@@ -28,8 +27,8 @@ class DatasetRow extends Component {
                     {filesize(this.props.size, { standard: "iec" })})
                 </td>
             </tr>,
-            <tr>
-                <td colspan="2" className="hiddentablerow p-0">
+            <tr key={`child_${this.props.id}`}>
+                <td colSpan="2" className="hiddentablerow p-0">
                     <div
                         className="accordian-body collapse"
                         id={"collapsed_" + this.props.id}


### PR DESCRIPTION
List of things I've noticed and fixed:

`mr` becomes `me`
`ml` becomes `ms`
`badge-pill` becomes `rounded-pill`
`badge-secondary` becomes `bg-secondary` (ditto for other priorities)
`data-toggle` becomes `data-bs-toggle`

And fixed old problems: `colspan` -> `colSpan`, added `key` in some places it was missing.

Now everything is togglable and the tags are visible:
![image](https://user-images.githubusercontent.com/7026881/206537745-efdcd4a3-ce72-4650-b4a5-bc678a8057c8.png)


Fixes #294