### PR TITLE
Added datasets-taking-too-long warning

### DIFF
--- a/src/mqueryfront/src/components/ErrorBoundary.js
+++ b/src/mqueryfront/src/components/ErrorBoundary.js
@@ -19,17 +19,18 @@ class ErrorBoundary extends Component {
     }
 
     render() {
-        if (this.state.error) {
-            return (
+        return (
+            <>
+            {this.state.error && (
                 <div className="container-fluid">
                     <div className="alert alert-danger">
                         {this.state.error.toString()}
                     </div>
                 </div>
-            );
-        }
-
-        return this.props.children;
+            )}
+            {this.props.children}
+            </>
+        );
     }
 }
 

--- a/src/mqueryfront/src/status/BackendStatus.js
+++ b/src/mqueryfront/src/status/BackendStatus.js
@@ -1,5 +1,8 @@
 import React, { Component } from "react";
 
+import ErrorBoundary from "../components/ErrorBoundary";
+
+
 class BackendJobRow extends Component {
     render() {
         let shortRequest = this.props.request;
@@ -75,7 +78,11 @@ class BackendStatus extends Component {
             />
         ));
 
-        return <div>{agentRows}</div>;
+        return (
+            <ErrorBoundary error={!agentRows.length && "No agents found."}>
+                <div>{agentRows}</div>
+            </ErrorBoundary>
+        );
     }
 }
 

--- a/src/mqueryfront/src/status/DatabaseTopology.js
+++ b/src/mqueryfront/src/status/DatabaseTopology.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import filesize from "filesize";
 
 import ErrorBoundary from "../components/ErrorBoundary";
+import { withTimeout } from "../utils";
 import api from "../api";
 
 class DatasetRow extends Component {
@@ -65,13 +66,18 @@ class DatabaseTopology extends Component {
     }
 
     componentDidMount() {
-        api.get("/backend/datasets")
-            .then((response) => {
-                this.setState({ datasets: response.data.datasets });
-            })
-            .catch((error) => {
-                this.setState({ error: error });
-            });
+        withTimeout(
+            api.get,
+            "/backend/datasets",
+            () => this.setState({ error: "Loading topology is taking too long. Consider compaction." }),
+            5000
+        )
+        .then((response) => {
+            this.setState({ datasets: response.data.datasets });
+        })
+        .catch((error) => {
+            this.setState({ error: error });
+        });
     }
 
     index() {

--- a/src/mqueryfront/src/utils.js
+++ b/src/mqueryfront/src/utils.js
@@ -18,3 +18,13 @@ export const getProgressBarClass = (status) => {
 
 export const isAuthEnabled = (config) =>
     config && config["auth_enabled"] && config["auth_enabled"] !== "false";
+
+export const withTimeout = (callback, param, timeout_callback, time) => {
+    var success = false;
+    return (() => {
+        setTimeout(() => {
+            if (!success) timeout_callback()
+        }, time);
+        return callback(param).then((res) => { success = true; return res });
+    })();
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [X] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [X] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Errors in `ErrorBoundary` are conditionally rendered, so it's either them or the actual content. Changed it so errors are visible alongside the content. Also, code is missing some hinting at errors as described in #307 

Some points to think about:   
* what if there are actual errors (not this warning) that come from the api call? It seems like a "race condition" of errors may happen, don't feel like I've uncovered all test cases
* unable to distinguish between real errors (API call fails because server is down, for example) and warnings

**What is the new behaviour?**
Shows a warning (should maybe be recolored to yellow?) that compaction should be considered in case fetching api took > 5 seconds.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

(partially) fixes #307 
