### PR TITLE
Fix regression - actually raise errors from API

### DIFF
--- a/src/mqueryfront/src/api.js
+++ b/src/mqueryfront/src/api.js
@@ -22,7 +22,7 @@ function request(method, path, payload, params) {
             if (error.response.status === 401) {
                 window.location = "/auth";
             }
-            return error;
+            throw error;
         });
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Looks like I've introduced a regression to mquery by wrapping API call in an additional check. This causes the API to return the error instead of raising it.

**What is the new behaviour?**
Error is correctly raised.

**Test plan**
Write a bad yara rule, run it, you should see the error message:

![image](https://user-images.githubusercontent.com/7026881/209243490-7a57414a-fde8-4b9f-a865-35b1d508f7f7.png)


<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

fixes #310
