### PR TITLE
Make it possible to disallow slow queries (or warn user about the problem)

### DIFF
--- a/docs/yara.md
+++ b/docs/yara.md
@@ -215,3 +215,25 @@ the rule could cripple mquery performance.
 Remember that parser is your friend. If your query runs too slow, click "parse" instead
 of "query" and investigate if the query looks reasonable.
 
+## Slow Yara rules.
+
+Some yara rules cannot be optimised by mquery and will end up scanning the whole
+malware collection. One example of such rule is:
+
+```
+rule UnluckyExample
+{
+    strings:
+        $code = {48 8b 0? 0f b6 c? 48 8b 4? 34 50}
+
+    condition:
+        all of them and pe.imphash() == "b8bb385806b89680e13fc0cf24f4431e"
+}
+```
+
+This is not necessarily a bad rule, but there's not a single full 3gram that can
+be used to narrow the set of suspected files. Due to how mquery works, this will
+yara scan every malware file in the dataset, and will be very slow. Becaue of this,
+such queries are by defauly disasllowed. They can be enabled by setting
+`query_allow_slow` config key to true. In this case mquery will allow such
+queries, but it'll ask for confirmation first.

--- a/src/app.py
+++ b/src/app.py
@@ -18,7 +18,7 @@ from starlette.responses import Response, FileResponse, StreamingResponse  # typ
 from starlette.staticfiles import StaticFiles  # type: ignore
 from zmq import Again
 
-from lib.yaraparse import YaraRuleData, parse_yara
+from lib.yaraparse import parse_yara
 
 from util import mquery_version
 from db import Database, JobId

--- a/src/app.py
+++ b/src/app.py
@@ -342,16 +342,20 @@ def query(
         ]
 
     degenerate_rules = [r.name for r in rules if r.parse().is_degenerate]
-    if degenerate_rules:
+    disallow_degenerate = db.get_mquery_config_key("query_disallow_degenerate")
+    if degenerate_rules and (disallow_degenerate == "true"):
         degenerate_rule_names = ", ".join(degenerate_rules)
         doc_url = "https://cert-polska.github.io/mquery/docs/yara.html"
-        raise HTTPException(status_code=400, detail=(
-            "Invalid query. "
-            "Some of the rules would require a Yara scan of every indexed "
-            "file, and this is not allowed by this instance. "
-            f"Problematic rules: {degenerate_rule_names}. "
-            f"Read {doc_url} for more details."
-        ))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Invalid query. "
+                "Some of the rules would require a Yara scan of every indexed "
+                "file, and this is not allowed by this instance. "
+                f"Problematic rules: {degenerate_rule_names}. "
+                f"Read {doc_url} for more details."
+            ),
+        )
 
     active_agents = db.get_active_agents()
 

--- a/src/app.py
+++ b/src/app.py
@@ -343,7 +343,7 @@ def query(
 
     degenerate_rules = [r.name for r in rules if r.parse().is_degenerate]
     disallow_degenerate = db.get_mquery_config_key("query_disallow_degenerate")
-    if degenerate_rules and (disallow_degenerate == "true"):
+    if degenerate_rules and disallow_degenerate == "true":
         degenerate_rule_names = ", ".join(degenerate_rules)
         doc_url = "https://cert-polska.github.io/mquery/docs/yara.html"
         raise HTTPException(

--- a/src/app.py
+++ b/src/app.py
@@ -342,11 +342,9 @@ def query(
         ]
 
     degenerate_rules = [r.name for r in rules if r.parse().is_degenerate]
-    if degenerate_rules and not data.force_slow_queries:
-        allow_slow_queries = (
-            db.get_mquery_config_key("query_allow_slow") == "true"
-        )
-        if allow_slow_queries:
+    allow_slow = db.get_mquery_config_key("query_allow_slow") == "true"
+    if degenerate_rules and not (allow_slow and data.force_slow_queries):
+        if allow_slow:
             # Warning: "You can force a slow query" literal is used to
             # pattern match on the error message in the frontend.
             help_message = "You can force a slow query if you want."
@@ -357,7 +355,7 @@ def query(
         raise HTTPException(
             status_code=400,
             detail=(
-                "Invalid query. Some of the rules require a full Yara scan of "
+                "Invalid query. Some of the rules require a full Yara scan of"
                 "every indexed file. "
                 f"{help_message} "
                 f"Slow rules: {degenerate_rule_names}. "

--- a/src/app.py
+++ b/src/app.py
@@ -343,10 +343,10 @@ def query(
 
     degenerate_rules = [r.name for r in rules if r.parse().is_degenerate]
     if degenerate_rules and not data.force_slow_queries:
-        allow_degenerate = (
-            db.get_mquery_config_key("query_disallow_degenerate") != "true"
+        allow_slow_queries = (
+            db.get_mquery_config_key("query_allow_slow") == "true"
         )
-        if allow_degenerate:
+        if allow_slow_queries:
             # Warning: "You can force a slow query" literal is used to
             # pattern match on the error message in the frontend.
             help_message = "You can force a slow query if you want."
@@ -357,7 +357,7 @@ def query(
         raise HTTPException(
             status_code=400,
             detail=(
-                "Invalid query. Some of the rules require a full Yara scan of"
+                "Invalid query. Some of the rules require a full Yara scan of "
                 "every indexed file. "
                 f"{help_message} "
                 f"Slow rules: {degenerate_rule_names}. "

--- a/src/db.py
+++ b/src/db.py
@@ -332,7 +332,7 @@ class Database:
             "openid_client_id": "OpenID client ID",
             "openid_secret": "Secret used for JWT token verification",
             # Query and performance config
-            "query_disallow_degenerate": "Reject any queries that will end up scanning the whole malware collection",
+            "query_allow_slow": "Allow users to run queries that will end up scanning the whole malware collection",
         }
 
     def get_config(self) -> List[ConfigSchema]:

--- a/src/db.py
+++ b/src/db.py
@@ -331,6 +331,8 @@ class Database:
             "openid_url": "OpenID Connect base url",
             "openid_client_id": "OpenID client ID",
             "openid_secret": "Secret used for JWT token verification",
+            # Query and performance config
+            "query_disallow_degenerate": "Reject any queries that will end up scanning the whole malware collection",
         }
 
     def get_config(self) -> List[ConfigSchema]:

--- a/src/mqueryfront/src/config/ConfigEntries.js
+++ b/src/mqueryfront/src/config/ConfigEntries.js
@@ -10,6 +10,7 @@ const KNOWN_RULES = {
     openid_url: R_URL,
     auth_enabled: R_BOOL,
     auth_default_roles: R_ROLES,
+    query_disallow_degenerate: R_BOOL,
 };
 
 class ConfigRow extends Component {

--- a/src/mqueryfront/src/config/ConfigEntries.js
+++ b/src/mqueryfront/src/config/ConfigEntries.js
@@ -10,7 +10,7 @@ const KNOWN_RULES = {
     openid_url: R_URL,
     auth_enabled: R_BOOL,
     auth_default_roles: R_ROLES,
-    query_disallow_degenerate: R_BOOL,
+    query_allow_slow: R_BOOL,
 };
 
 class ConfigRow extends Component {

--- a/src/mqueryfront/src/query/QueryField.js
+++ b/src/mqueryfront/src/query/QueryField.js
@@ -12,6 +12,7 @@ const QueryField = (props) => (
             onTaintSelect={props.onTaintSelect}
             availableTaints={props.availableTaints}
             selectedTaints={props.selectedTaints}
+            forceSlowQueries={props.forceSlowQueries}
         />
         <div className="mt-2 monaco-container">
             <QueryMonaco

--- a/src/mqueryfront/src/query/QueryLayoutManager.js
+++ b/src/mqueryfront/src/query/QueryLayoutManager.js
@@ -60,8 +60,6 @@ const QueryLayoutManager = (props) => {
         queryResults
     ) : null;
 
-    // const queryResultOrParse = qhash ? queryResults : queryParse;
-
     const queryFieldPane = isCollapsed ? null : (
         <div className={resultsTab ? "col-md-6" : "col-md-12"}>
             <QueryField

--- a/src/mqueryfront/src/query/QueryLayoutManager.js
+++ b/src/mqueryfront/src/query/QueryLayoutManager.js
@@ -27,13 +27,8 @@ const QueryLayoutManager = (props) => {
         onYaraUpdate,
         parsedError,
         selectedTaints,
+        forceSlowQueries,
     } = props;
-
-    const queryParse = queryError ? (
-        <ErrorPage error={queryError} />
-    ) : queryPlan ? (
-        <QueryParseStatus queryPlan={queryPlan} />
-    ) : null;
 
     const queryResults = job ? (
         <div>
@@ -57,10 +52,18 @@ const QueryLayoutManager = (props) => {
         <LoadingPage />
     );
 
-    const queryResultOrParse = qhash ? queryResults : queryParse;
+    const resultsTab = queryError ? (
+        <ErrorPage error={queryError} />
+    ) : queryPlan ? (
+        <QueryParseStatus queryPlan={queryPlan} />
+    ) : qhash ? (
+        queryResults
+    ) : null;
+
+    // const queryResultOrParse = qhash ? queryResults : queryParse;
 
     const queryFieldPane = isCollapsed ? null : (
-        <div className={queryResultOrParse ? "col-md-6" : "col-md-12"}>
+        <div className={resultsTab ? "col-md-6" : "col-md-12"}>
             <QueryField
                 readOnly={!!qhash}
                 onSubmitQuery={onSubmitQuery}
@@ -72,6 +75,7 @@ const QueryLayoutManager = (props) => {
                 onYaraUpdate={onYaraUpdate}
                 parsedError={parsedError}
                 selectedTaints={selectedTaints}
+                forceSlowQueries={forceSlowQueries}
             />
         </div>
     );
@@ -87,7 +91,7 @@ const QueryLayoutManager = (props) => {
                             : "col-md-6 order-first order-md-last"
                     }
                 >
-                    {queryResultOrParse}
+                    {resultsTab}
                 </div>
             </div>
         </div>

--- a/src/mqueryfront/src/query/QueryNavigation.js
+++ b/src/mqueryfront/src/query/QueryNavigation.js
@@ -12,11 +12,15 @@ const QueryNavigation = (props) => {
         isEditActive,
         availableTaints,
         selectedTaints,
+        forceSlowQueries,
     } = props;
 
     return (
         <div className="btn-group" role="group">
-            <QuerySubmitNav onClick={onSubmitQuery} />
+            <QuerySubmitNav
+                onClick={onSubmitQuery}
+                forceMode={forceSlowQueries}
+            />
             <QueryEditParseNav
                 isEditActive={isEditActive}
                 onEditQuery={onEditQuery}

--- a/src/mqueryfront/src/query/QueryPage.js
+++ b/src/mqueryfront/src/query/QueryPage.js
@@ -15,6 +15,7 @@ const INITIAL_STATE = {
     selectedTaints: [],
     job: null,
     activePage: 1,
+    forceSlowQueries: false,
 };
 
 const PAGE_SIZE = 20;
@@ -94,6 +95,9 @@ class QueryPageInner extends Component {
     };
 
     handleYaraUpdate(value) {
+        this.setState({
+            forceSlowQueries: false,
+        });
         this.setState({ rawYara: value });
     }
 
@@ -167,6 +171,7 @@ class QueryPageInner extends Component {
                 method: method,
                 priority: priority,
                 taints: taints,
+                force_slow_queries: this.state.forceSlowQueries,
             });
             if (method === "query") {
                 this.props.navigate(`/query/${response.data.query_hash}`);
@@ -183,6 +188,11 @@ class QueryPageInner extends Component {
                     : error.toString(),
                 queryPlan: null,
             });
+            if (this.state.queryError.match(/You can force a slow query/)) {
+                this.setState({
+                    forceSlowQueries: true,
+                });
+            }
         }
     }
 
@@ -249,6 +259,7 @@ class QueryPageInner extends Component {
                     onYaraUpdate={this.handleYaraUpdate}
                     parsedError={this.parsedError}
                     selectedTaints={this.state.selectedTaints}
+                    forceSlowQueries={this.state.forceSlowQueries}
                 />
             </ErrorBoundary>
         );

--- a/src/mqueryfront/src/query/QueryParseStatus.js
+++ b/src/mqueryfront/src/query/QueryParseStatus.js
@@ -6,14 +6,18 @@ const QueryParseStatus = (props) => {
     if (!queryPlan) return null;
 
     const parseResult = queryPlan.map((rule) => {
-        const { is_private, is_global, rule_name, parsed } = rule;
+        const { is_private, is_global, is_degenerate, rule_name, parsed } = rule;
 
-        const badge =
-            is_private || is_global ? (
-                <span className="badge badge-info">
-                    {is_private ? "private" : "global"}
-                </span>
+        const private_badge =is_private ?(
+                <span className="badge bg-info">private</span>
             ) : null;
+        const global_badge =is_global?(
+                <span className="badge bg-info">private</span>
+            ) : null;
+        const degenerate_badge =is_degenerate?(
+                <span className="badge bg-danger">degenerate</span>
+            ) : null;
+        const badges = <>{private_badge} {global_badge} {degenerate_badge}</>;
 
         return (
             <div key={rule_name} className="mt-3">
@@ -22,7 +26,7 @@ const QueryParseStatus = (props) => {
                         <span className="me-2 font-weight-bold">
                             {rule_name}
                         </span>
-                        {badge}
+                        {badges}
                     </label>
                     <div className="jumbotron text-monospace text-break p-2">
                         {parsed}

--- a/src/mqueryfront/src/query/QueryParseStatus.js
+++ b/src/mqueryfront/src/query/QueryParseStatus.js
@@ -6,18 +6,28 @@ const QueryParseStatus = (props) => {
     if (!queryPlan) return null;
 
     const parseResult = queryPlan.map((rule) => {
-        const { is_private, is_global, is_degenerate, rule_name, parsed } = rule;
+        const {
+            is_private,
+            is_global,
+            is_degenerate,
+            rule_name,
+            parsed,
+        } = rule;
 
-        const private_badge =is_private ?(
-                <span className="badge bg-info">private</span>
-            ) : null;
-        const global_badge =is_global?(
-                <span className="badge bg-info">private</span>
-            ) : null;
-        const degenerate_badge =is_degenerate?(
-                <span className="badge bg-danger">degenerate</span>
-            ) : null;
-        const badges = <>{private_badge} {global_badge} {degenerate_badge}</>;
+        const private_badge = is_private ? (
+            <span className="badge bg-info">private</span>
+        ) : null;
+        const global_badge = is_global ? (
+            <span className="badge bg-info">private</span>
+        ) : null;
+        const degenerate_badge = is_degenerate ? (
+            <span className="badge bg-danger">degenerate</span>
+        ) : null;
+        const badges = (
+            <>
+                {private_badge} {global_badge} {degenerate_badge}
+            </>
+        );
 
         return (
             <div key={rule_name} className="mt-3">

--- a/src/mqueryfront/src/query/QuerySubmitNav.js
+++ b/src/mqueryfront/src/query/QuerySubmitNav.js
@@ -1,23 +1,25 @@
 import React from "react";
 
 const QuerySubmitNav = (props) => {
-    const { onClick } = props;
+    const { onClick, forceMode } = props;
+
+    const label = forceMode ? "Force query (may be very slow!)" : "Query";
+    const style = forceMode ? "btn-danger" : "btn-success";
 
     return (
         <React.Fragment>
             <button
                 type="button"
-                className="btn btn-success btn-sm"
+                className={"btn btn-sm " + style}
                 onClick={() => onClick("medium")}
             >
-                Query
+                {label}
             </button>
-            <div className="btn-group" role="group">
+            <div className="btn-group">
                 <button
                     type="button"
-                    className="btn btn-success dropdown-toggle"
-                    data-toggle="dropdown"
-                    aria-haspopup="true"
+                    className={"btn dropdown-toggle " + style}
+                    data-bs-toggle="dropdown"
                     aria-expanded="false"
                 />
                 <div className="dropdown-menu">

--- a/src/mqueryfront/src/status/BackendStatus.js
+++ b/src/mqueryfront/src/status/BackendStatus.js
@@ -32,7 +32,7 @@ class AgentStatus extends Component {
         let badge = null;
         if (!this.props.alive) {
             badge = (
-                <span className="badge badge-secondary badge-sm">offline</span>
+                <span className="badge bg-secondary badge-sm">offline</span>
             );
         }
 

--- a/src/schema.py
+++ b/src/schema.py
@@ -65,6 +65,7 @@ class QueryRequestSchema(BaseModel):
     files_limit: Optional[int]
     reference: Optional[str]  # arbitrary data specified by the user
     required_plugins: List[str] = Field([])
+    force_slow_queries: bool = False
 
 
 class QueryResponseSchema(BaseModel):

--- a/src/schema.py
+++ b/src/schema.py
@@ -76,6 +76,7 @@ class ParseResponseSchema(BaseModel):
     rule_author: str
     is_global: bool
     is_private: bool
+    is_degenerate: bool
     parsed: str
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable) - not yet, I'll add a separate issue for documentation update

**What is the current behaviour?**

#308 

>Currently, people who don't understand how mquery and mwdb work behind the scene can execute very bad yara queries and it'll be (a) expensive (b) inefficient (c) take forever to run.

**What is the new behaviour?**

![image](https://user-images.githubusercontent.com/7026881/209887840-2305e3c1-878a-439f-8de7-31c2310d7a40.png)

If configuration option `query_disallow_degenerate` is set to "true", users won't be able to run any queries that would end up doing a whole backend scan. Of course they can still run very inefficient queries like `"aaa" | "bbb" | ccc" | "ddd"` or just `{00 00 00}`, so this won't help in every case, but that's all we can do at this stage (others will be handled by #297).

I know this is not exactly what #308 asked for. I wonder if anyone really wants to use the "soft" mode - warn only, don't reject the query. If not, I think it's good as just a configuration option.

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #308
