### PR TITLE
Fix filename collection in the index script

### DIFF
--- a/src/utils/index.py
+++ b/src/utils/index.py
@@ -13,10 +13,10 @@ def all_indexed_files(ursa: UrsaDb) -> Set[str]:
     result: Set[str] = set()
     while True:
         pop_result = ursa.pop(iterator, 10000)
-        if pop_result.iterator_empty:
-            break
         for fpath in pop_result.files:
             result.add(fpath)
+        if pop_result.iterator_empty:
+            break
     return result
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
I **swear** I already fixed this twice.

`iterator_empty` means that the iterator has no more files (and was dropped from the DB), but not necessary that no files were returned. The check order is incorrect.

**What is the new behaviour?**
The check order is correct. This is very important, because otherwise every invocation of utils.index may index duplicate files.

