### PR TITLE
Fix the progress bar

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -112,6 +112,7 @@ class Database:
             taints=json.loads(data.get("taints", "[]")),
             total_datasets=data.get("total_datasets", 0),
             datasets_left=data.get("datasets_left", 0),
+            agents_left=data.get("agents_left", 0),
         )
 
     def remove_query(self, job: JobId) -> None:

--- a/src/mqueryfront/src/components/QueryProgressBar.js
+++ b/src/mqueryfront/src/components/QueryProgressBar.js
@@ -54,7 +54,6 @@ const QueryProgressBar = (props) => {
     const datasetPct = Math.round(datasetFrac * 100);
 
     // TODO: remove the "failed" status after merging #317
-    console.log(status);
     if (status == "cancelled" || status == "failed") {
         return finalProgressBar(job, "query cancelled", "bg-danger");
     }

--- a/src/mqueryfront/src/components/QueryProgressBar.js
+++ b/src/mqueryfront/src/components/QueryProgressBar.js
@@ -1,9 +1,36 @@
 import React from "react";
 import ActionCancel from "./ActionCancel";
 import QueryTimer from "./QueryTimer";
-import { isStatusFinished, getProgressBarClass } from "../utils";
+import { isStatusFinished } from "../utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+
+const finalProgressBar = (job, text, cssBg) => (
+    <div>
+        <div className="progress">
+            <div
+                className={"progress-bar " + cssBg}
+                role="progressbar"
+                style={{ width: "100%" }}
+                data-toggle="tooltip"
+                title={text}
+            >
+                {text}
+            </div>
+        </div>
+        <div>
+            <div className="float-right">
+                <QueryTimer
+                    job={job}
+                    isFinished={true}
+                    duration={true}
+                    countDown={true}
+                />
+            </div>
+            <div className="clearfix"></div>
+        </div>
+    </div>
+);
 
 const QueryProgressBar = (props) => {
     const { job, compact, onCancel } = props;
@@ -16,66 +43,73 @@ const QueryProgressBar = (props) => {
         files_matched,
         total_datasets,
         datasets_left,
+        agents_left,
     } = job;
+
+    const getPercentage = (files) =>
+        total_files ? Math.round((files * datasetFrac * 100) / total_files) : 0;
 
     const datasetsDone = total_datasets - datasets_left;
     const datasetFrac = total_datasets > 0 ? datasetsDone / total_datasets : 0;
     const datasetPct = Math.round(datasetFrac * 100);
 
-    const getPercentage = (files) =>
-        total_files ? Math.round((files * datasetFrac * 100) / total_files) : 0;
+    // TODO: remove the "failed" status after merging #317
+    console.log(status);
+    if (status == "cancelled" || status == "failed") {
+        return finalProgressBar(job, "query cancelled", "bg-danger");
+    }
 
     const isFinished = isStatusFinished(status);
     const inProgeressPct = getPercentage(files_in_progress);
     const erroredPct = getPercentage(files_errored);
+    const filesSuccess = files_processed - files_errored;
     const processedPct =
-        total_files === 0 && isFinished ? 100 : getPercentage(files_processed);
+        total_files === 0 && isFinished ? 100 : getPercentage(filesSuccess);
 
-    const errorString = files_errored === 1 ? "error" : "errors";
-    const errorTooltip = `${files_errored} ${errorString} during processing`;
-
+    let statusInfo = "";
     const matches = `${files_matched} matches`;
-    let statusInfo = null;
-    if (total_datasets === 0 && status === "new") {
-        statusInfo = "Collecting datasets...";
-    } else if (datasets_left > 0) {
-        statusInfo = `Searching for candidates: ${datasetsDone}/${total_datasets} (${datasetPct}%)...`;
-    } else if (status === "processing") {
-        statusInfo = `Matching Yara: ${files_processed} / ${total_files} (${processedPct}%), ${matches}`;
+    const matches_long = `${matches} (out of ${total_files} candidates)`;
+    if (agents_left > 0) {
+        statusInfo += `Backends working: ${agents_left}. `;
     }
-
+    if (total_datasets === 0 && status === "new") {
+        statusInfo += "Collecting datasets. ";
+    }
+    if (datasets_left > 0) {
+        statusInfo += `Querying datasets: ${datasetsDone}/${total_datasets} (${datasetPct}%). `;
+    }
+    if (status === "processing" && files_processed < total_files) {
+        statusInfo += `Matching Yara: ${files_processed} / ${total_files} (${processedPct}%), ${matches}. `;
+    }
     return (
         <div>
             <div className="progress">
                 <div
-                    className={getProgressBarClass(status)}
+                    className={"progress-bar bg-success"}
                     role="progressbar"
                     style={{ width: processedPct + "%" }}
                     data-toggle="tooltip"
-                    title={status}
+                    title={`${filesSuccess} files checked`}
                 >
                     {Math.round(processedPct)}%
                 </div>
-                {total_files > 0 && inProgeressPct > 0 && (
-                    <div
-                        className={"progress-bar bg-warning"}
-                        role="progressbar"
-                        style={{ width: inProgeressPct + "%" }}
-                    ></div>
-                )}
-                {files_errored > 0 && (
-                    <div
-                        className={"progress-bar bg-danger"}
-                        role="progressbar"
-                        style={{ width: erroredPct + "%" }}
-                        data-toggle="tooltip"
-                        title={errorTooltip}
-                    />
-                )}
+                <div
+                    className={"progress-bar bg-warning"}
+                    role="progressbar"
+                    style={{ width: inProgeressPct + "%" }}
+                    title={`${files_in_progress} files in progress`}
+                ></div>
+                <div
+                    className={"progress-bar bg-danger"}
+                    role="progressbar"
+                    style={{ width: erroredPct + "%" }}
+                    data-toggle="tooltip"
+                    title={`${files_errored} files errored when checking`}
+                />
             </div>
             <div className={compact ? "small" : ""}>
                 <div className="float-left">
-                    {statusInfo && (
+                    {!isFinished && (
                         <FontAwesomeIcon
                             icon={faSpinner}
                             spin
@@ -83,7 +117,7 @@ const QueryProgressBar = (props) => {
                             className="me-1"
                         />
                     )}
-                    {statusInfo || matches}
+                    {statusInfo || (compact ? matches : matches_long)}
                 </div>
                 <div className="float-right">
                     <QueryTimer

--- a/src/mqueryfront/src/query/QueryResultsStatus.js
+++ b/src/mqueryfront/src/query/QueryResultsStatus.js
@@ -6,6 +6,7 @@ const QueryResultsStatus = (props) => {
     const { job, matches, qhash, pagination, onCancel } = props;
     const { status, files_matched } = job;
 
+    // TODO: remove after merging #317
     if (status === "expired") {
         return (
             <div className="mquery-scroll-matches">

--- a/src/mqueryfront/src/utils.js
+++ b/src/mqueryfront/src/utils.js
@@ -5,15 +5,10 @@ const statusClassMap = {
     done: "success",
     new: "info",
     processing: "info",
-    expired: "warning",
+    expired: "warning", // TODO: remove after merging #317
     cancelled: "danger",
-    failed: "danger",
+    failed: "danger", // TODO: remove after merging #317
     removed: "dark",
-};
-
-export const getProgressBarClass = (status) => {
-    const classSufix = statusClassMap[status];
-    return "progress-bar" + (classSufix ? " bg-" + classSufix : "");
 };
 
 export const isAuthEnabled = (config) =>

--- a/src/schema.py
+++ b/src/schema.py
@@ -24,6 +24,7 @@ class JobSchema(BaseModel):
     taints: List[str]
     datasets_left: int
     total_datasets: int
+    agents_left: int
 
 
 class JobsSchema(BaseModel):


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Explained in issue #319

**What is the new behaviour?**

This is a mix PR between "features" and "bugfixes"

> If an error happens before datasets are collected, progress bar stays in the "collecting datasets" state (even though job is cancelled already)

This one is fixed.

> If an error happens before all agents are queried, progress bar stays incomplete forever (even though job is cancelled)

This one too.

> Progress bar behaves in a non-obvious way (because of a complex logic I won't explain here). There actually two progress bars in one - one thing we track is how many ursadb datasets were queried, and the second is how many candidates from ursadb were scanned with yara. I still think we should show what actually happens, but in a more understandable way to the user.

I improved (?) it by adding a more elaborate description. In some cases it can get as long as this:

![image](https://user-images.githubusercontent.com/7026881/213031374-f0c1e75b-85a6-48d1-adee-9b9bb060c90e.png)

Irrelevant parts are not shown (for example, when all datasets are queried and collected already, only "matching: " part is visible.

I'm not sure about including the part `Backends working: 1`. It may be confusing, but on the other hand it explains progress bars like this:

![image](https://user-images.githubusercontent.com/7026881/213031578-cec050cc-36fc-4b5e-b474-4f0da1063287.png)

Without the number of backends working visible it's very uncler why the query is still in progress (this is because in this case there were 10 dead backends configured).

> Don't double-count errored and processed files (when file errors out, we increment files_errored counter. But we always show all processed files as green. So for example if all files fail, we show 50% green 50% red progress bar)

Fixed.

> I would also like to see the number of files checked with yara (maybe also with some % of true positives, to let the user know how good their rule is)

Another UI change I'm not sure about. When the query is done, and only in the query view, matches are shown next to a number of candidates:

![image](https://user-images.githubusercontent.com/7026881/213031938-c7806494-f87d-41a7-b055-29384d48acb4.png)

This is a very useful feature for me (as a developer and maybe a poewr user), not sure about the others.


**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #319
