### PR TITLE
Make it possible to limit the number of yara-scanned files

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -20,7 +20,7 @@ class MqueryConfig(Config):
     plugins = key(cast=str, required=False, default="")
     # Maximum number of yara-scanned files per query (0 means no limit).
     yara_limit = key(cast=int, required=False, default=0)
-    # Html code to be displayed on the about page. 
+    # Html code to be displayed on the about page.
     about = key(cast=str, required=False, default="")
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -5,14 +5,21 @@ import os
 
 @section("redis")
 class RedisConfig(Config):
+    # Hostname of a configured redis instance.
     host = key(cast=str, required=False, default="localhost")
+    # Port of a configured redis instance.
     port = key(cast=int, required=False, default=6379)
 
 
 @section("mquery")
 class MqueryConfig(Config):
+    # URL to a UrsaDB instance.
     backend = key(cast=str, required=False, default="tcp://127.0.0.1:9281")
+    # List of plugin specifications separated by comma, for example
+    # "plugins.archive:GzipPlugin, plugins.custom:CustomPlugin"
     plugins = key(cast=str, required=False, default="")
+    # Maximum number of yara-scanned files per query (0 means no limit).
+    yara_limit = key(cast=int, required=False, default=0)
 
 
 class AppConfig(Config):

--- a/src/db.py
+++ b/src/db.py
@@ -149,13 +149,14 @@ class Database:
     def job_update_work(
         self, job: JobId, processed: int, matched: int, errored: int
     ) -> None:
-        """Update progress for the job. This will increment number of files processed
-        and matched, and if as a result all files are processed, will change the job
-        status to `done`"""
-        self.redis.hincrby(f"job:{job}", "files_processed", processed)
+        """Updates progress for the job. This will increment numbers processed,
+        inprogress, errored and matched files.
+        This will return the number of processed files after the operation."""
+        files = self.redis.hincrby(f"job:{job}", "files_processed", processed)
         self.redis.hincrby(f"job:{job}", "files_in_progress", -processed)
         self.redis.hincrby(f"job:{job}", "files_matched", matched)
         self.redis.hincrby(f"job:{job}", "files_errored", errored)
+        return files
 
     def init_job_datasets(self, job: JobId, num_datasets: int) -> None:
         """Sets total_datasets and datasets_left, and status to processing"""

--- a/src/db.py
+++ b/src/db.py
@@ -148,7 +148,7 @@ class Database:
 
     def job_update_work(
         self, job: JobId, processed: int, matched: int, errored: int
-    ) -> None:
+    ) -> int:
         """Updates progress for the job. This will increment numbers processed,
         inprogress, errored and matched files.
         This will return the number of processed files after the operation."""

--- a/src/db.py
+++ b/src/db.py
@@ -151,7 +151,7 @@ class Database:
     ) -> int:
         """Updates progress for the job. This will increment numbers processed,
         inprogress, errored and matched files.
-        This will return the number of processed files after the operation."""
+        Returns the number of processed files after the operation."""
         files = self.redis.hincrby(f"job:{job}", "files_processed", processed)
         self.redis.hincrby(f"job:{job}", "files_in_progress", -processed)
         self.redis.hincrby(f"job:{job}", "files_matched", matched)

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -120,7 +120,7 @@ class Agent:
         if yara_limit != 0 and new_processed > yara_limit:
             self.db.fail_job(
                 job.id,
-                f"Configured limit of yara matches ({yara_limit}) exceeded. "
+                f"Configured limit of yara matches ({yara_limit}) exceeded",
             )
 
     def add_tasks_in_progress(self, job: JobSchema, tasks: int) -> None:

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -116,10 +116,11 @@ class Agent:
         new_processed = self.db.job_update_work(
             job.id, num_files, num_matches, num_errors
         )
-        if new_processed > config.YARA_LIMIT:
+        yara_limit = app_config.mquery.yara_limit
+        if yara_limit != 0 and new_processed > yara_limit:
             self.db.fail_job(
-                job,
-                f"Configured limit of yara matches ({config.YARA_LIMIT}) exceeded"
+                job.id,
+                f"Configured limit of yara matches ({yara_limit}) exceeded. "
             )
 
     def add_tasks_in_progress(self, job: JobSchema, tasks: int) -> None:

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -113,7 +113,14 @@ class Agent:
                 num_errors += 1
 
         self.plugins.cleanup()
-        self.db.job_update_work(job.id, num_files, num_matches, num_errors)
+        new_processed = self.db.job_update_work(
+            job.id, num_files, num_matches, num_errors
+        )
+        if new_processed > config.YARA_LIMIT:
+            self.db.fail_job(
+                job,
+                f"Configured limit of yara matches ({config.YARA_LIMIT}) exceeded"
+            )
 
     def add_tasks_in_progress(self, job: JobSchema, tasks: int) -> None:
         """See documentation of db.agent_add_tasks_in_progress"""


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Issue #297

**What is the new behaviour?**
This is a draft of a solution. It won't work yet, because I want to use typedconfg here after it's merged.

**Test plan**

1. Change the mquery.yara_limit config variable to something other than the default 0
2. Run a query that would return significantly more results than this
3. Ensure that the query does **not** return successfully. Instead it is cancelled as soon as it crosses the configured threshold of checked samples:
![image](https://user-images.githubusercontent.com/7026881/214412771-56a2fb0c-016a-48b1-9722-bb75c9c4941e.png)


**Closing issues**

fixes #297
