### PR TITLE
Remove old status types

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -79,6 +79,11 @@ class Database:
     def get_job(self, job: JobId) -> JobSchema:
         """Retrieves a job from the database. Tries to fix corrupted objects"""
         data = self.redis.hgetall(f"job:{job}")
+        if data.get("status") in ["expired", "failed"]:
+            # There is no support for migrations in Redis "databases".
+            # These are old statuses, not used in the new versions anymore.
+            data["status"] = "cancelled"
+
         return JobSchema(
             id=job,
             status=data.get("status", "ERROR"),

--- a/src/mqueryfront/src/components/QueryProgressBar.js
+++ b/src/mqueryfront/src/components/QueryProgressBar.js
@@ -53,8 +53,7 @@ const QueryProgressBar = (props) => {
     const datasetFrac = total_datasets > 0 ? datasetsDone / total_datasets : 0;
     const datasetPct = Math.round(datasetFrac * 100);
 
-    // TODO: remove the "failed" status after merging #317
-    if (status == "cancelled" || status == "failed") {
+    if (status == "cancelled") {
         return finalProgressBar(job, "query cancelled", "bg-danger");
     }
 

--- a/src/mqueryfront/src/query/QueryResultsStatus.js
+++ b/src/mqueryfront/src/query/QueryResultsStatus.js
@@ -5,16 +5,6 @@ import QueryMatches from "./QueryMatches";
 const QueryResultsStatus = (props) => {
     const { job, matches, qhash, pagination, onCancel } = props;
     const { status, files_matched } = job;
-
-    // TODO: remove after merging #317
-    if (status === "expired") {
-        return (
-            <div className="mquery-scroll-matches">
-                Search results expired. Please run the query once again.
-            </div>
-        );
-    }
-
     let results = null;
 
     if (job.error) {

--- a/src/mqueryfront/src/utils.js
+++ b/src/mqueryfront/src/utils.js
@@ -1,13 +1,11 @@
 export const isStatusFinished = (status) =>
-    ["done", "cancelled", "failed", "expired", "removed"].includes(status);
+    ["done", "cancelled", "removed"].includes(status);
 
 const statusClassMap = {
     done: "success",
     new: "info",
     processing: "info",
-    expired: "warning", // TODO: remove after merging #317
     cancelled: "danger",
-    failed: "danger", // TODO: remove after merging #317
     removed: "dark",
 };
 

--- a/src/utils/mquery.py
+++ b/src/utils/mquery.py
@@ -77,7 +77,7 @@ def process_job(
 
             offset += 1
 
-        FINISHED_STATES = ["cancelled", "failed", "done", "removed"]
+        FINISHED_STATES = ["cancelled", "done"]
         if not matches:
             if out["job"]["status"] in FINISHED_STATES:
                 break


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Code handles some old, currently unused statuses

**What is the new behaviour?**
Dead code is removed. One ugly thing is that we need a fallback for the old statuses still in the database, since there is no mechanism for data migration in Redis (maybe we can hand-roll our own someday, unless we somehow decide to go with #74)  

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

