### PR TITLE
Add a configurable about page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -545,7 +545,7 @@ def server() -> ServerSchema:
         auth_enabled=db.get_mquery_config_key("auth_enabled"),
         openid_url=db.get_mquery_config_key("openid_url"),
         openid_client_id=db.get_mquery_config_key("openid_client_id"),
-        about=app_config.mquery.about
+        about=app_config.mquery.about,
     )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -545,6 +545,9 @@ def server() -> ServerSchema:
         auth_enabled=db.get_mquery_config_key("auth_enabled"),
         openid_url=db.get_mquery_config_key("openid_url"),
         openid_client_id=db.get_mquery_config_key("openid_client_id"),
+        # This is - of course - subject to change. I want to use typed config
+        # for this. For now, this PR is a draft.
+        about="Hello world from this <b>mquery</b> instance."
     )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -545,9 +545,7 @@ def server() -> ServerSchema:
         auth_enabled=db.get_mquery_config_key("auth_enabled"),
         openid_url=db.get_mquery_config_key("openid_url"),
         openid_client_id=db.get_mquery_config_key("openid_client_id"),
-        # This is - of course - subject to change. I want to use typed config
-        # for this. For now, this PR is a draft.
-        about="Hello world from this <b>mquery</b> instance.",
+        about=app_config.mquery.about
     )
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -547,7 +547,7 @@ def server() -> ServerSchema:
         openid_client_id=db.get_mquery_config_key("openid_client_id"),
         # This is - of course - subject to change. I want to use typed config
         # for this. For now, this PR is a draft.
-        about="Hello world from this <b>mquery</b> instance."
+        about="Hello world from this <b>mquery</b> instance.",
     )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,7 @@ class RedisConfig(Config):
 class MqueryConfig(Config):
     backend = key(cast=str, required=False, default="tcp://127.0.0.1:9281")
     plugins = key(cast=str, required=False, default="")
+    about = key(cast=str, required=False, default="")
 
 
 class AppConfig(Config):

--- a/src/mqueryfront/src/App.js
+++ b/src/mqueryfront/src/App.js
@@ -5,6 +5,7 @@ import QueryPage from "./query/QueryPage";
 import RecentPage from "./recent/RecentPage";
 import StatusPage from "./status/StatusPage";
 import ConfigPage from "./config/ConfigPage";
+import AboutPage from "./about/AboutPage";
 import AuthPage from "./auth/AuthPage";
 import api, { parseJWT } from "./api";
 import "./App.css";
@@ -49,6 +50,11 @@ function App() {
                 <Route exact path="/recent" element={<RecentPage />} />
                 <Route exact path="/config" element={<ConfigPage />} />
                 <Route exact path="/status" element={<StatusPage />} />
+                <Route
+                    exact
+                    path="/about"
+                    element={<AboutPage config={config} />}
+                />
                 <Route
                     exact
                     path="/auth"

--- a/src/mqueryfront/src/Navigation.js
+++ b/src/mqueryfront/src/Navigation.js
@@ -4,8 +4,9 @@ import { ReactComponent as Logo } from "./logo.svg";
 import { isAuthEnabled, openidLoginUrl } from "./utils";
 
 function Navigation(props) {
+    const authEnabled = isAuthEnabled(props.config);
+    const aboutHtml = props.config ? props.config.about : null;
     let loginElm = null;
-    let authEnabled = isAuthEnabled(props.config);
     let isAdmin = false;
     if (!authEnabled) {
         isAdmin = true; // Auth is disabled - everyone is an admin.
@@ -33,59 +34,68 @@ function Navigation(props) {
 
     return (
         <nav className="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
-            <Link className="navbar-brand" to={"/"}>
-                <Logo width="150" height="100%" />
-            </Link>
-            <button
-                className="navbar-toggler"
-                type="button"
-                data-toggle="collapse"
-                data-target="#navbarSupportedContent"
-                aria-controls="navbarSupportedContent"
-                aria-expanded="false"
-                aria-label="Toggle navigation"
-            >
-                <span className="navbar-toggler-icon" />
-            </button>
+            <div className="container-fluid">
+                <Link className="navbar-brand" to={"/"}>
+                    <Logo width="150" />
+                </Link>
+                <button
+                    className="navbar-toggler"
+                    type="button"
+                    data-toggle="collapse"
+                    data-target="#navbarSupportedContent"
+                    aria-controls="navbarSupportedContent"
+                    aria-expanded="false"
+                    aria-label="Toggle navigation"
+                >
+                    <span className="navbar-toggler-icon" />
+                </button>
 
-            <div
-                className="collapse navbar-collapse"
-                id="navbarSupportedContent"
-            >
-                <ul className="navbar-nav me-auto">
-                    <li className="nav-item">
-                        <Link className="nav-link" to={"/"}>
-                            Query
-                        </Link>
-                    </li>
-                    <li className="nav-item">
-                        <Link className="nav-link" to={"/recent"}>
-                            Recent jobs
-                        </Link>
-                    </li>
-                    {isAdmin ? (
+                <div
+                    className="collapse navbar-collapse"
+                    id="navbarSupportedContent"
+                >
+                    <ul className="navbar-nav me-auto">
                         <li className="nav-item">
-                            <Link className="nav-link" to={"/config"}>
-                                Config
+                            <Link className="nav-link" to={"/"}>
+                                Query
                             </Link>
                         </li>
-                    ) : null}
-                    {isAdmin ? (
                         <li className="nav-item">
-                            <Link className="nav-link" to={"/status"}>
-                                Status
+                            <Link className="nav-link" to={"/recent"}>
+                                Recent jobs
                             </Link>
                         </li>
-                    ) : null}
-                </ul>
-                <ul className="navbar-nav navbar-right">
-                    <li className="nav-item nav-right">
-                        <a className="nav-link" href="/docs">
-                            API Docs
-                        </a>
-                    </li>
-                    {loginElm}
-                </ul>
+                        {isAdmin ? (
+                            <li className="nav-item">
+                                <Link className="nav-link" to={"/config"}>
+                                    Config
+                                </Link>
+                            </li>
+                        ) : null}
+                        {isAdmin ? (
+                            <li className="nav-item">
+                                <Link className="nav-link" to={"/status"}>
+                                    Status
+                                </Link>
+                            </li>
+                        ) : null}
+                        {aboutHtml ? (
+                            <li className="nav-item">
+                                <Link className="nav-link" to={"/about"}>
+                                    About
+                                </Link>
+                            </li>
+                        ) : null}
+                    </ul>
+                    <ul className="navbar-nav navbar-right">
+                        <li className="nav-item nav-right">
+                            <a className="nav-link" href="/docs">
+                                API Docs
+                            </a>
+                        </li>
+                        {loginElm}
+                    </ul>
+                </div>
             </div>
         </nav>
     );

--- a/src/mqueryfront/src/about/AboutPage.js
+++ b/src/mqueryfront/src/about/AboutPage.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+const AboutPage = (props) => {
+    const aboutHtml = props.config ? props.config.about : null;
+    return (
+        <div className="container-fluid">
+            <div className="p-5 mb-4 bg-light rounded-3">
+                <div className="container-fluid py-5">
+                    <h1 className="display-5 fw-bold">About this instance</h1>
+                    <p
+                        className="col-md-8 fs-4"
+                        dangerouslySetInnerHTML={{ __html: aboutHtml }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default AboutPage;

--- a/src/schema.py
+++ b/src/schema.py
@@ -130,5 +130,4 @@ class ServerSchema(BaseModel):
     auth_enabled: Optional[str]
     openid_url: Optional[str]
     openid_client_id: Optional[str]
-    about: Optional[str]
-    """HTML code to be displayed on the /about page."""
+    about: str

--- a/src/schema.py
+++ b/src/schema.py
@@ -130,3 +130,5 @@ class ServerSchema(BaseModel):
     auth_enabled: Optional[str]
     openid_url: Optional[str]
     openid_client_id: Optional[str]
+    about: Optional[str]
+    """HTML code to be displayed on the /about page."""


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
There is no way to add any customised information for the users #323 

**What is the new behaviour?**
This PR adds (will add) a customisable "about" page. It's not very customisable, because all the information will have to fit into a config file, but that should be enough to give users a few URLs or explain what's going on.

![image](https://user-images.githubusercontent.com/7026881/213897865-6497c627-ead5-47dc-b75c-fd63a6d53278.png)

This subpage is optional (will be optional in the final PR).

I've decided to allow HTML (it's trusted - it comes from the server) instead of just plain text.

**Test plan**

Visit /about.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #323 
