### PR TITLE
Plugin requirements install in web dockerfile

### DIFF
--- a/deploy/docker/daemon.Dockerfile
+++ b/deploy/docker/daemon.Dockerfile
@@ -1,8 +1,11 @@
 FROM python:3.10
 
 RUN apt update; apt install -y cmake
+
 COPY "requirements.txt" "/tmp/requirements.txt"
 RUN pip install -r /tmp/requirements.txt
+
+# plugin requirements
 # requirements.txt is added because at least one file must exist
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
 RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,

--- a/deploy/docker/daemon.Dockerfile
+++ b/deploy/docker/daemon.Dockerfile
@@ -4,7 +4,7 @@ RUN apt update; apt install -y cmake
 
 # mquery and plugin requirements
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
-RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
+RUN ls /tmp/requirements*.txt | xargs -i,, pip --no-cache-dir install -r ,,
 
 COPY "src/" "/app"
 RUN chmod +x "/app/daemon.py"

--- a/deploy/docker/daemon.Dockerfile
+++ b/deploy/docker/daemon.Dockerfile
@@ -2,11 +2,7 @@ FROM python:3.10
 
 RUN apt update; apt install -y cmake
 
-COPY "requirements.txt" "/tmp/requirements.txt"
-RUN pip install -r /tmp/requirements.txt
-
-# plugin requirements
-# requirements.txt is added because at least one file must exist
+# mquery and plugin requirements
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
 RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
 

--- a/deploy/docker/dev.daemon.Dockerfile
+++ b/deploy/docker/dev.daemon.Dockerfile
@@ -3,12 +3,10 @@ FROM python:3.10
 WORKDIR /usr/src/app/src
 
 RUN apt update; apt install -y cmake
-COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
 
 # mquery and plugin requirements
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
-RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
+RUN ls /tmp/requirements*.txt | xargs -i,, pip --no-cache-dir install -r ,,
 
 # ./src is expected to be mounted with a docker volume
 CMD ["./autoreload", "python3", "daemon.py"]

--- a/deploy/docker/dev.daemon.Dockerfile
+++ b/deploy/docker/dev.daemon.Dockerfile
@@ -5,8 +5,10 @@ WORKDIR /usr/src/app/src
 RUN apt update; apt install -y cmake
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-# requirements.txt is added because at least one file must exist
+
+# mquery and plugin requirements
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
 RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
+
 # ./src is expected to be mounted with a docker volume
 CMD ["./autoreload", "python3", "daemon.py"]

--- a/deploy/docker/dev.web.Dockerfile
+++ b/deploy/docker/dev.web.Dockerfile
@@ -4,10 +4,9 @@ WORKDIR /usr/src/app/src
 
 RUN apt update; apt install -y cmake
 
-# plugin requirements
-# requirements.txt is added because at least one file must exist
+# mquery and plugin requirements
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
-RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
+RUN ls /tmp/requirements*.txt | xargs -i,, pip --no-cache-dir install -r ,,
 
 # ./src is expected to be mounted with a docker volume
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000", "--reload"]

--- a/deploy/docker/dev.web.Dockerfile
+++ b/deploy/docker/dev.web.Dockerfile
@@ -3,7 +3,11 @@ FROM python:3.10
 WORKDIR /usr/src/app/src
 
 RUN apt update; apt install -y cmake
-COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+
+# plugin requirements
+# requirements.txt is added because at least one file must exist
+COPY requirements.txt src/plugins/requirements-*.txt /tmp/
+RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
+
 # ./src is expected to be mounted with a docker volume
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000", "--reload"]

--- a/deploy/docker/web.Dockerfile
+++ b/deploy/docker/web.Dockerfile
@@ -11,13 +11,9 @@ WORKDIR /usr/src/app/src
 
 RUN apt update; apt install -y cmake
 
-COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
-
-# plugin requirements
-# requirements.txt is added because at least one file must exist
+# mquery and plugin requirements
 COPY requirements.txt src/plugins/requirements-*.txt /tmp/
-RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
+RUN ls /tmp/requirements*.txt | xargs -i,, pip --no-cache-dir install -r ,,
 
 COPY "src/." "."
 COPY --from=build "/app/build" "./mqueryfront/build"

--- a/deploy/docker/web.Dockerfile
+++ b/deploy/docker/web.Dockerfile
@@ -10,8 +10,15 @@ FROM python:3.10
 WORKDIR /usr/src/app/src
 
 RUN apt update; apt install -y cmake
+
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
+
+# plugin requirements
+# requirements.txt is added because at least one file must exist
+COPY requirements.txt src/plugins/requirements-*.txt /tmp/
+RUN ls /tmp/requirements-*.txt | xargs -i,, pip --no-cache-dir install -r ,,
+
 COPY "src/." "."
 COPY --from=build "/app/build" "./mqueryfront/build"
 COPY "src/config.docker.py" "config.py"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [ ] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
The web dockerfile build fails in case some plugin uses a python module not present in vanilla mquery due to the use of `PluginManager` and plugin loading in `app.py`

**What is the new behaviour?**
Build is successful.

**Test plan**
Build it and see if operational. I've tested this change with a plugin that uses `boto3` and it seems to work.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
