### PR TITLE
Fix the /about route

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -559,6 +559,7 @@ def serve_index(path: str) -> FileResponse:
 @app.get("/query", include_in_schema=False)
 @app.get("/config", include_in_schema=False)
 @app.get("/auth", include_in_schema=False)
+@app.get("/about", include_in_schema=False)
 def serve_index_sub() -> FileResponse:
     # Static routes are always publicly accessible without authorisation.
     return FileResponse("mqueryfront/build/index.html")


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Users can't visit `/about` route directly. It's handled by react on the client side, but server responds 404 to it. We already made this mistake before.

**What is the new behaviour?**
going to `/about` route directly works

**Test plan**
Visit /about.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->
