### PR TITLE
Give more details about the query progress before cancel

### DIFF
--- a/src/mqueryfront/src/components/QueryProgressBar.js
+++ b/src/mqueryfront/src/components/QueryProgressBar.js
@@ -5,13 +5,13 @@ import { isStatusFinished } from "../utils";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 
-const finalProgressBar = (job, text, cssBg) => (
+const finalProgressBar = (job, text, cssBg, progress = 100) => (
     <div>
         <div className="progress">
             <div
                 className={"progress-bar " + cssBg}
                 role="progressbar"
-                style={{ width: "100%" }}
+                style={{ width: `${progress}%` }}
                 data-toggle="tooltip"
                 title={text}
             >
@@ -53,16 +53,17 @@ const QueryProgressBar = (props) => {
     const datasetFrac = total_datasets > 0 ? datasetsDone / total_datasets : 0;
     const datasetPct = Math.round(datasetFrac * 100);
 
-    if (status == "cancelled") {
-        return finalProgressBar(job, "query cancelled", "bg-danger");
-    }
-
     const isFinished = isStatusFinished(status);
     const inProgeressPct = getPercentage(files_in_progress);
     const erroredPct = getPercentage(files_errored);
     const filesSuccess = files_processed - files_errored;
     const processedPct =
         total_files === 0 && isFinished ? 100 : getPercentage(filesSuccess);
+
+    if (status == "cancelled") {
+        const percent = processedPct;
+        return finalProgressBar(job, "query cancelled", "bg-danger", percent);
+    }
 
     let statusInfo = "";
     const matches = `${files_matched} matches`;

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -118,9 +118,14 @@ class Agent:
         )
         yara_limit = app_config.mquery.yara_limit
         if yara_limit != 0 and new_processed > yara_limit:
+            scan_percent = new_processed / job.total_files
+            scanned_datasets = job.total_datasets - job.datasets_left
+            dataset_percent = scanned_datasets / job.total_datasets
             self.db.fail_job(
                 job.id,
-                f"Configured limit of yara matches ({yara_limit}) exceeded",
+                f"Configured limit of {yara_limit} YARA matches exceeded. "
+                f"Scanned {new_processed}/{job.total_files} ({scan_percent:.0%}) of candidates "
+                f"in {scanned_datasets}/{job.total_datasets} ({dataset_percent:.0%}) of datasets.",
             )
 
     def add_tasks_in_progress(self, job: JobSchema, tasks: int) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Cancelled progress bar is always full, and the user has no information about how close (or far) was it from completion:

![image](https://user-images.githubusercontent.com/7026881/214923376-842c1e20-3732-4d09-885a-ad8d8a0932c5.png)

**What is the new behaviour?**
The error message is more clear (I hope), and the progress bar reflects the job status:

![image](https://user-images.githubusercontent.com/7026881/214923586-f036649f-d640-4355-8a65-88c9677d46d7.png)

(Yes, I know there's a lot of information in that message to process. But I don't see an easier way. There are all kinds of situations possible, for example 100/100 files scanned in 1/100 datasets (so effectively 1% done) or 100/100 files scnaned in 99/100 datasets (so effectively 99% done). Progress bar takes the number of datasets into account to predict the real total number of files, so without this information error message would be misleading). 

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

