### PR TITLE
Assign rules to users

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -89,7 +89,7 @@ class Database:
             status=data.get("status", "ERROR"),
             error=data.get("error", None),
             rule_name=data.get("rule_name", "ERROR"),
-            rule_author=data.get("rule_author", None),
+            rule_author=data.get("rule_author", "unknown"),
             raw_yara=data.get("raw_yara", "ERROR"),
             submitted=data.get("submitted", 0),
             finished=data.get("finished", None),

--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -126,14 +126,6 @@ class YaraRuleData:
     def is_private(self) -> bool:
         return self.rule.is_private
 
-    @property
-    def author(self) -> str:
-        author_meta = self.rule.get_meta_with_name("author")
-        if author_meta:
-            return author_meta.value.pure_text
-        else:
-            return ""
-
 
 def ursify_hex(hex_str: str) -> UrsaExpression:
     # easier to manage

--- a/src/schema.py
+++ b/src/schema.py
@@ -8,7 +8,7 @@ class JobSchema(BaseModel):
     status: str
     error: Optional[str]
     rule_name: str
-    rule_author: Optional[str]
+    rule_author: str
     raw_yara: str
     submitted: int
     finished: Optional[int]


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable) - TODO

**What is the current behaviour?**
There is no user permission model for listing (or cancelling etc) recent jobs

**What is the new behaviour?**
Only the owning user (and admin) can see their jobs. Only the owning user (and admin) can cancel and remove their jobs.
