### PR TITLE
rq task timeout in config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,9 +41,7 @@ Currently, supported configuration keys are:
   example `plugins.archive:GzipPlugin, plugins.custom:CustomPlugin`)
 - `mquery.yara_limit`: Maximum number of yara-scanned files per query (0 means no limit).
 - `mquery.about`: HTML code to be displayed on the about page.
-- `rq.start_timeout`: Timeout value for task initiation (in seconds). The default is OK for most users.
-- `rq.ursadb_timeout`: Timeout value (in seconds) for a ursadb query. The default is OK for most users.
-- `rq.yara_timeout`: Timeout value (in seconds) for yara scanning a batch of files. The default is OK for most users.
+- `rq.job_timeout`: Timeout value for rq jobs. The default is OK for most users.
 
 ## Mquery plugin configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,11 @@ Currently, supported configuration keys are:
   `tcp://ursadb-server:9281`)
 - `mquery.plugins`: List of supported plugins, separated by commas (for
   example `plugins.archive:GzipPlugin, plugins.custom:CustomPlugin`)
+- `mquery.yara_limit`: Maximum number of yara-scanned files per query (0 means no limit).
+- `mquery.about`: HTML code to be displayed on the about page.
+- `rq.start_timeout`: Timeout value for task initiation (in seconds). The default is OK for most users.
+- `rq.ursadb_timeout`: Timeout value (in seconds) for a ursadb query. The default is OK for most users.
+- `rq.yara_timeout`: Timeout value (in seconds) for yara scanning a batch of files. The default is OK for most users.
 
 ## Mquery plugin configuration
 

--- a/src/config.py
+++ b/src/config.py
@@ -11,6 +11,12 @@ class RedisConfig(Config):
     port = key(cast=int, required=False, default=6379)
 
 
+@section("rq")
+class RqConfig(Config):
+    # Maximum timeout value for tasks (in seconds)
+    timeout = key(cast=int, required=False, default=180)
+
+
 @section("mquery")
 class MqueryConfig(Config):
     # URL to a UrsaDB instance.
@@ -26,6 +32,7 @@ class MqueryConfig(Config):
 
 class AppConfig(Config):
     redis = group_key(RedisConfig)
+    rq = group_key(RqConfig)
     mquery = group_key(MqueryConfig)
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -13,8 +13,15 @@ class RedisConfig(Config):
 
 @section("rq")
 class RqConfig(Config):
-    # Maximum timeout value for tasks (in seconds)
-    timeout = key(cast=int, required=False, default=180)
+    # Timeout value for task initiation (in seconds). In most cases this is
+    # instant, so 60 seconds is very generous.
+    start_timeout = key(cast=int, required=False, default=60)
+    # Timeout value (in seconds) for a ursadb query.
+    ursadb_timeout = key(cast=int, required=False, default=600)
+    # Timeout value (in seconds) for yara scanning a batch of files.
+    # In some cases this may take some time (for example, when a large
+    # batch of files is downloaded from a remote storage).
+    yara_timeout = key(cast=int, required=False, default=600)
 
 
 @section("mquery")

--- a/src/config.py
+++ b/src/config.py
@@ -13,15 +13,8 @@ class RedisConfig(Config):
 
 @section("rq")
 class RqConfig(Config):
-    # Timeout value for task initiation (in seconds). In most cases this is
-    # instant, so 60 seconds is very generous.
-    start_timeout = key(cast=int, required=False, default=60)
-    # Timeout value (in seconds) for a ursadb query.
-    ursadb_timeout = key(cast=int, required=False, default=600)
-    # Timeout value (in seconds) for yara scanning a batch of files.
-    # In some cases this may take some time (for example, when a large
-    # batch of files is downloaded from a remote storage).
-    yara_timeout = key(cast=int, required=False, default=600)
+    # Timeout value for rq jobs.
+    job_timeout = key(cast=int, required=False, default=300)
 
 
 @section("mquery")

--- a/src/db.py
+++ b/src/db.py
@@ -58,7 +58,7 @@ class Database:
     def __schedule(self, agent: str, task: Any, *args: Any) -> None:
         """Schedules the task to agent group `agent` using rq."""
         Queue(agent, connection=self.redis).enqueue(
-            task, *args, job_timeout=app_config.rq.start_timeout
+            task, *args, job_timeout=app_config.rq.job_timeout
         )
 
     def get_job_ids(self) -> List[JobId]:

--- a/src/db.py
+++ b/src/db.py
@@ -57,7 +57,9 @@ class Database:
 
     def __schedule(self, agent: str, task: Any, *args: Any) -> None:
         """Schedules the task to agent group `agent` using rq."""
-        Queue(agent, connection=self.redis).enqueue(task, *args, job_timeout=app_config.rq.timeout)
+        Queue(agent, connection=self.redis).enqueue(
+            task, *args, job_timeout=app_config.rq.timeout
+        )
 
     def get_job_ids(self) -> List[JobId]:
         """Gets IDs of all jobs in the database"""

--- a/src/db.py
+++ b/src/db.py
@@ -58,7 +58,7 @@ class Database:
     def __schedule(self, agent: str, task: Any, *args: Any) -> None:
         """Schedules the task to agent group `agent` using rq."""
         Queue(agent, connection=self.redis).enqueue(
-            task, *args, job_timeout=app_config.rq.timeout
+            task, *args, job_timeout=app_config.rq.start_timeout
         )
 
     def get_job_ids(self) -> List[JobId]:

--- a/src/db.py
+++ b/src/db.py
@@ -5,6 +5,7 @@ from time import time
 import json
 import random
 import string
+from config import app_config
 from redis import StrictRedis
 from enum import Enum
 from rq import Queue  # type: ignore
@@ -56,7 +57,7 @@ class Database:
 
     def __schedule(self, agent: str, task: Any, *args: Any) -> None:
         """Schedules the task to agent group `agent` using rq."""
-        Queue(agent, connection=self.redis).enqueue(task, *args)
+        Queue(agent, connection=self.redis).enqueue(task, *args, job_timeout=app_config.rq.timeout)
 
     def get_job_ids(self) -> List[JobId]:
         """Gets IDs of all jobs in the database"""

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -192,7 +192,7 @@ def start_search(job_id: JobId) -> None:
                 dataset,
                 parsed.query,
                 depends_on=prev_job,
-                job_timeout=app_config.rq.ursadb_timeout,
+                job_timeout=app_config.rq.job_timeout,
             )
 
 
@@ -243,7 +243,7 @@ def query_ursadb(job_id: JobId, dataset_id: str, ursadb_query: str) -> None:
                 job_id,
                 iterator,
                 batch,
-                job_timeout=app_config.rq.yara_timeout,
+                job_timeout=app_config.rq.job_timeout,
             )
 
         agent.db.dataset_query_done(job_id)
@@ -266,7 +266,7 @@ def run_yara_batch(job_id: JobId, iterator: str, batch_size: int) -> None:
                 job_id,
                 iterator,
                 batch_size,
-                job_timeout=app_config.rq.yara_timeout,
+                job_timeout=app_config.rq.job_timeout,
             )
             return
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -192,7 +192,7 @@ def start_search(job_id: JobId) -> None:
                 dataset,
                 parsed.query,
                 depends_on=prev_job,
-                job_timeout=app_config.rq.ursadb_timeout
+                job_timeout=app_config.rq.ursadb_timeout,
             )
 
 
@@ -243,7 +243,7 @@ def query_ursadb(job_id: JobId, dataset_id: str, ursadb_query: str) -> None:
                 job_id,
                 iterator,
                 batch,
-                job_timeout=app_config.rq.yara_timeout
+                job_timeout=app_config.rq.yara_timeout,
             )
 
         agent.db.dataset_query_done(job_id)
@@ -266,7 +266,7 @@ def run_yara_batch(job_id: JobId, iterator: str, batch_size: int) -> None:
                 job_id,
                 iterator,
                 batch_size,
-                job_timeout=app_config.rq.yara_timeout
+                job_timeout=app_config.rq.yara_timeout,
             )
             return
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
This whole PR is based on a `rq.timeouts.JobTimeoutException` error during YARA matching in one of my plugins:
```python
Traceback (most recent call last):
  File "/app/plugins/SomePlugin.py", line 106, in filter
    shutil.copyfileobj(f_in, f_out)
  File "/usr/local/lib/python3.10/shutil.py", line 198, in copyfileobj
    fdst_write(buf)
  File "/usr/local/lib/python3.10/site-packages/rq/timeouts.py", line 61, in handle_death_penalty
    raise self._exception('Task exceeded maximum timeout value '
rq.timeouts.JobTimeoutException: Task exceeded maximum timeout value (180 seconds)
```
Consequently, I get these at the worker:  
```python
INFO:rq.worker:Killed horse pid 6434
INFO:rq.worker:Killed horse pid 6435
WARNING:rq.worker:Moving job to FailedJobRegistry (work-horse terminated unexpectedly; waitpid returned None)
WARNING:rq.worker:Moving job to FailedJobRegistry (work-horse terminated unexpectedly; waitpid returned None)
```  
And the most troublesome part is that the query hangs in 99%, which makes me believe mquery currently lacks rq-level error handling; a way to cleanup and gracefully shutdown search in case of such errors.

**What is the new behaviour?**
This PR adds a way to control top-level queued task timeout in `__schedule` method. Because code still needs to be tested this is currently in draft.  
Also, might check on the "query hangs on 99%" part in this PR, or leave it as is with just the config value, we'll see 🦆  

**Test plan**
<!-- Explain how to test your changes -->
TBD  