### PR TITLE
Raise 401 on invalid token

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -119,9 +119,12 @@ async def current_user(authorization: Optional[str] = Header(None)) -> User:
             token, public_key, algorithms=["RS256"], audience="account"  # type: ignore
         )
     except jwt.InvalidTokenError:
-        # A generic signature error. Maybe we should raise 401 here, but on the
-        # other hand we don't want to raise 401 if auth_enabled is not enabled.
-        return User(None)
+        # Invalid token means invalid signature, issuer, or just expired.
+        # Return 401 and allow the user to re-authenticate.
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid token, please re-authenticate.",
+        )
 
     return User(token_json)
 

--- a/src/app.py
+++ b/src/app.py
@@ -105,13 +105,22 @@ async def current_user(authorization: Optional[str] = Header(None)) -> User:
     if not authorization:
         return User(None)
 
-    bearer, token = authorization.split()
-    if bearer != "Bearer":
-        return User(None)
+    # 401 error object, that will force the user to re-authenticate.
+    unauthorized = HTTPException(
+        status_code=401,
+        detail="Invalid token, please re-authenticate.",
+    )
+
+    # Be nice for the user, even when they send us an invalid header.
+    token_parts = authorization.split()
+    if len(token_parts) != 2 or token_parts[0] != "Bearer":
+        raise unauthorized
+
+    _bearer, token = token_parts
 
     secret = db.get_mquery_config_key("openid_secret")
     if secret is None:
-        return User(None)
+        raise RuntimeError("Invalid configuration - missing_openid_secret.")
 
     public_key = serialization.load_der_public_key(base64.b64decode(secret))  # type: ignore
     try:
@@ -120,11 +129,7 @@ async def current_user(authorization: Optional[str] = Header(None)) -> User:
         )
     except jwt.InvalidTokenError:
         # Invalid token means invalid signature, issuer, or just expired.
-        # Return 401 and allow the user to re-authenticate.
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid token, please re-authenticate.",
-        )
+        raise unauthorized
 
     return User(token_json)
 

--- a/src/mqueryfront/src/App.js
+++ b/src/mqueryfront/src/App.js
@@ -10,10 +10,17 @@ import AuthPage from "./auth/AuthPage";
 import api, { parseJWT } from "./api";
 import "./App.css";
 
+function getCurrentTokenOrNull() {
+    // This function handles missing and corrupted token in the same way.
+    try {
+        return parseJWT(localStorage.getItem("rawToken"));
+    } catch {
+        return null;
+    }
+}
+
 function App() {
     const [config, setConfig] = useState(null);
-    const rawToken = localStorage.getItem("rawToken");
-    const token = rawToken ? parseJWT(rawToken) : null;
 
     useEffect(() => {
         api.get("/server").then((response) => {
@@ -40,6 +47,8 @@ function App() {
             window.location.href = "/";
         }
     };
+
+    const token = getCurrentTokenOrNull();
 
     return (
         <div className="App">


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Keycloak invalidates the sessions after some time. But because of how we handle invalid signatures, user may still use the website anonymously (even though the UI says they're logged in), as long as they don't do any admin-only stuff.

**What is the new behaviour?**
This PR will raise 401 on invalid signature, and overall makes the login status more robust.

I also recommend people to change the token timeout to a longer value - 30 minutes is a bit short.

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->
