### PR TITLE
Fix a deadlock in the plugin manager

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,5 @@
 from lib.ursadb import UrsaDb
 import os
-from threading import Lock
 
 import uvicorn  # type: ignore
 from config import app_config
@@ -11,7 +10,6 @@ from fastapi import (
     HTTPException,
     Depends,
     Header,
-    BackgroundTasks,
 )  # type: ignore
 from starlette.requests import Request  # type: ignore
 from starlette.responses import Response, FileResponse, StreamingResponse  # type: ignore


### PR DESCRIPTION
I'm not even sure why the deadlock is there, but it happens on the server. Removing the global pluginmanager is a good idea anyway, at a small cost of performance we remove ugly manual locking.

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Sometimes the webserver deadlocks. At least I think it's a deadlock. I suspect this piece of code I'm removing in this PR.

**What is the new behaviour?**
There is no manual locking, so no chance of deadlock. Additionally, the code becomes cleaner and there's no problem with plugin cleanup - all at just a small cost of performance.

Draft, because I forgot to actually cleanup files (I'll fix this later today).