### PR TITLE
Fix missing space in error

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -439,7 +439,7 @@ def query(
         raise HTTPException(
             status_code=400,
             detail=(
-                "Invalid query. Some of the rules require a full Yara scan of"
+                "Invalid query. Some of the rules require a full Yara scan of "
                 "every indexed file. "
                 f"{help_message} "
                 f"Slow rules: {degenerate_rule_names}. "


### PR DESCRIPTION
Noticed that a space is missing in the Slow Yara error. Fixed it.
![image](https://user-images.githubusercontent.com/20182642/236437168-4f4db9ea-1b08-44c6-a169-15f0502f86b0.png)
