### PR TITLE
It's `monospace`, not `"monospace"`

### DIFF
--- a/src/mqueryfront/src/App.css
+++ b/src/mqueryfront/src/App.css
@@ -10,7 +10,7 @@
 
 .mquery-scroll-matches td {
     word-break: break-all;
-    font-family: "monospace";
+    font-family: monospace;
 }
 
 .mquery-scroll-matches td i {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Styles are incorrect, and use a font called "monospace" instead of a literal monospace font - it doesn't work on windows apparently.

**What is the new behaviour?**
Mquery should work better on niche operating systems.
