### PR TITLE
Support Offline Usage by Making Monaco-Editor use Local Files

### DIFF
--- a/deploy/docker/dev.frontend.Dockerfile
+++ b/deploy/docker/dev.frontend.Dockerfile
@@ -3,5 +3,7 @@ FROM node:16 AS build
 RUN npm install -g serve
 COPY src/mqueryfront /app
 WORKDIR /app
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps && \
+    mkdir ./public/monaco-vs && \
+    cp -r ./node_modules/monaco-editor/min/vs/. ./public/monaco-vs
 CMD ["npm", "start"]

--- a/deploy/docker/web.Dockerfile
+++ b/deploy/docker/web.Dockerfile
@@ -3,7 +3,10 @@ FROM node:16 AS build
 RUN npm install -g serve
 COPY src/mqueryfront /app
 WORKDIR /app
-RUN npm install --legacy-peer-deps && npm run build
+RUN npm install --legacy-peer-deps && \
+    mkdir ./public/monaco-vs && \
+    cp -r ./node_modules/monaco-editor/min/vs/. ./public/monaco-vs && \
+    npm run build
 
 FROM python:3.10
 

--- a/src/mqueryfront/package.json
+++ b/src/mqueryfront/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@monaco-editor/react": "3.7.5",
+    "monaco-editor": "^0.21.2",
     "axios": "^1.3.4",
     "bootstrap": "^5.1.3",
     "filesize": "^8.0.6",

--- a/src/mqueryfront/src/query/QueryMonaco.js
+++ b/src/mqueryfront/src/query/QueryMonaco.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import Editor, { monaco } from "@monaco-editor/react";
 import YARA from "./yara-lang";
 
+monaco.config({ paths: { vs: "/monaco-vs" } });
+
 class QueryMonaco extends Component {
     constructor(props) {
         super(props);


### PR DESCRIPTION
By default, a dependency of Mquery, @monaco-editor/react, reaches to a CDN for files. This commit makes it so that these files (from monaco-editor, a peerDependency) are accessible locally under `{URL}/monaco-vs/...`. This allows for offline usage of Mquery.

<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- **N/A**: I've added automated tests for my change (if applicable, optional)
- **N/A**: I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->

Mquery reaches out to a CDN (cdn.jsdelivr.net) for files necessary for the Monaco-Editor component to work.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->

Mquery grabs the files necessary for the Monaco-Editor component locally from `{URL}/monaco-vs/...`.

**Current &rarr; New Behavior: Network Activity**

![screenshot of Firefox network activity in Mquery](https://github.com/CERT-Polska/mquery/assets/31434109/172fcd4f-e905-4e3d-95b5-e7a72633f4d7)

This image demonstrates network requests for editor files changing from the CDN to localhost.

**Test plan**
<!-- Explain how to test your changes -->

Use Mquery normally across each of these scenarios - witnessing the expected outcome.

- Current Version
  - Use online - works fine
  - Use offline - CDN server not found
- This Version
  - Use online - works fine
  - Use offline - works fine

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**
<!-- Add in issue numbers related to this PR, if applicable -->

_Not related to any current issues._
