### PR TITLE
Feature/postgres job

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -7,9 +7,10 @@ import string
 from redis import StrictRedis
 from enum import Enum
 from rq import Queue  # type: ignore
-from sqlmodel import Session, SQLModel, create_engine, select, and_
+from sqlmodel import Session, SQLModel, create_engine, select, and_, update
 
 from .models.configentry import ConfigEntry
+from .models.job import Job
 from .schema import JobSchema, MatchesSchema, AgentSpecSchema, ConfigSchema
 from .config import app_config
 
@@ -67,55 +68,44 @@ class Database:
 
     def get_job_ids(self) -> List[JobId]:
         """Gets IDs of all jobs in the database"""
-        return [key[4:] for key in self.redis.keys("job:*")]
+        with Session(self.engine) as session:
+            jobs = session.exec(select(Job)).all()
+            return [j.id for j in jobs]
 
-    def cancel_job(self, job: JobId) -> None:
-        """Sets the job status to cancelled"""
-        self.redis.hmset(
-            f"job:{job}",
-            {"status": "cancelled", "finished": int(time())},
-        )
+    def cancel_job(self, job: JobId, error=None) -> None:
+        """Sets the job status to cancelled, with optional error message"""
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(status="cancelled", finished=int(time()))
+            )
+            session.commit()
 
     def fail_job(self, job: JobId, message: str) -> None:
         """Sets the job status to cancelled with provided error message."""
-        self.redis.hmset(
-            f"job:{job}",
-            {"status": "cancelled", "error": message, "finished": int(time())},
-        )
+        self.cancel_job(job, message)
 
-    def get_job(self, job: JobId) -> JobSchema:
+    def __get_job(self, session: Session, job: JobId) -> Job:
+        """Internal helper - gets a job using the provided session"""
+        return session.exec(
+            select(Job).where(
+                Job.id == job,
+            )
+        ).one()
+
+    def get_job(self, job: JobId) -> Job:
         """Retrieves a job from the database. Tries to fix corrupted objects"""
-        data = self.redis.hgetall(f"job:{job}")
-        if data.get("status") in ["expired", "failed"]:
-            # There is no support for migrations in Redis "databases".
-            # These are old statuses, not used in the new versions anymore.
-            data["status"] = "cancelled"
-
-        return JobSchema(
-            id=job,
-            status=data.get("status", "ERROR"),
-            error=data.get("error", None),
-            rule_name=data.get("rule_name", "ERROR"),
-            rule_author=data.get("rule_author", "unknown"),
-            raw_yara=data.get("raw_yara", "ERROR"),
-            submitted=data.get("submitted", 0),
-            finished=data.get("finished", None),
-            files_limit=data.get("files_limit", 0),
-            files_processed=int(data.get("files_processed", 0)),
-            files_matched=int(data.get("files_matched", 0)),
-            files_in_progress=int(data.get("files_in_progress", 0)),
-            total_files=int(data.get("total_files", 0)),
-            files_errored=int(data.get("files_errored", 0)),
-            reference=data.get("reference", ""),
-            taints=json.loads(data.get("taints", "[]")),
-            total_datasets=data.get("total_datasets", 0),
-            datasets_left=data.get("datasets_left", 0),
-            agents_left=data.get("agents_left", 0),
-        )
+        with Session(self.engine) as sess:
+            return self.__get_job(sess, job)
 
     def remove_query(self, job: JobId) -> None:
         """Sets the job status to removed"""
-        self.redis.hmset(f"job:{job}", {"status": "removed"})
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job).where(Job.id == job).values(status="removed")
+            )
+            session.commit()
 
     def add_match(self, job: JobId, match: MatchInfo) -> None:
         self.redis.rpush(f"meta:{job}", match.to_json())
@@ -130,16 +120,33 @@ class Database:
         :param job: ID of the job being updated.
         :param in_progress: Number of files in the current work unit.
         """
-        self.redis.hincrby(f"job:{job}", "files_in_progress", in_progress)
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(files_in_progress=Job.files_in_progress + in_progress)
+            )
+            session.commit()
 
     def agent_finish_job(self, job: JobId) -> None:
         """Decrements the number of active agents in the given job. If there
         are no more agents, job status is changed to done."""
-        new_agents = self.redis.hincrby(f"job:{job}", "agents_left", -1)
-        if new_agents <= 0:
-            self.redis.hmset(
-                f"job:{job}", {"status": "done", "finished": int(time())}
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(agents_left=Job.agents_left - 1)
             )
+            session.commit()
+        with Session(self.engine) as session:
+            if self.__get_job(session, job).agents_left > 0:
+                return
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(finished=int(time()), status="done")
+            )
+            session.commit()
 
     def agent_add_tasks_in_progress(
         self, job: JobId, agent: str, tasks: int
@@ -159,21 +166,45 @@ class Database:
         """Updates progress for the job. This will increment numbers processed,
         inprogress, errored and matched files.
         Returns the number of processed files after the operation."""
-        files = self.redis.hincrby(f"job:{job}", "files_processed", processed)
-        self.redis.hincrby(f"job:{job}", "files_in_progress", -processed)
-        self.redis.hincrby(f"job:{job}", "files_matched", matched)
-        self.redis.hincrby(f"job:{job}", "files_errored", errored)
-        return files
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(
+                    files_processed=Job.files_processed + processed,
+                    files_in_progress=Job.files_in_progress - processed,
+                    files_matched=Job.files_matched + matched,
+                    files_errored=Job.files_errored + errored,
+                )
+            )
+            session.commit()
+        # This is a race condition but I think it's a "safe" one - it may return
+        # a bit higher value than the result of this update. To be fixed?
+        return self.get_job(job).files_processed
 
     def init_job_datasets(self, job: JobId, num_datasets: int) -> None:
         """Sets total_datasets and datasets_left, and status to processing"""
-        self.redis.hincrby(f"job:{job}", "total_datasets", num_datasets)
-        self.redis.hincrby(f"job:{job}", "datasets_left", num_datasets)
-        self.redis.hset(f"job:{job}", "status", "processing")
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(
+                    total_datasets=num_datasets,
+                    datasets_left=num_datasets,
+                    status="processing",
+                )
+            )
+            session.commit()
 
     def dataset_query_done(self, job: JobId):
         """Decrements the number of datasets left by one."""
-        self.redis.hincrby(f"job:{job}", "datasets_left", -1)
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(datasets_left=Job.datasets_left - 1)
+            )
+            session.commit()
 
     def create_search_task(
         self,
@@ -190,26 +221,29 @@ class Database:
             random.choice(string.ascii_uppercase + string.digits)
             for _ in range(12)
         )
-        job_obj = {
-            "status": "new",
-            "rule_name": rule_name,
-            "rule_author": rule_author,
-            "raw_yara": raw_yara,
-            "submitted": int(time()),
-            "files_limit": files_limit,
-            "reference": reference,
-            "files_in_progress": 0,
-            "files_processed": 0,
-            "files_matched": 0,
-            "files_errored": 0,
-            "total_files": 0,
-            "agents_left": len(agents),
-            "datasets_left": 0,
-            "total_datasets": 0,
-            "taints": json.dumps(taints),
-        }
+        with Session(self.engine) as session:
+            obj = Job(
+                id=job,
+                status="new",
+                rule_name=rule_name,
+                rule_author=rule_author,
+                raw_yara=raw_yara,
+                submitted=int(time()),
+                files_limit=files_limit,
+                reference=reference,
+                files_in_progress=0,
+                files_processed=0,
+                files_matched=0,
+                files_errored=0,
+                total_files=0,
+                agents_left=len(agents),
+                datasets_left=0,
+                total_datasets=0,
+                taints=taints,
+            )
+            session.add(obj)
+            session.commit()
 
-        self.redis.hmset(f"job:{job}", job_obj)
         from . import tasks
 
         for agent in agents:
@@ -235,7 +269,17 @@ class Database:
         return MatchesSchema(job=self.get_job(job), matches=matches)
 
     def update_job_files(self, job: JobId, total_files: int) -> int:
-        return self.redis.hincrby(f"job:{job}", "total_files", total_files)
+        """Add total_files to the specified job, and return a new total."""
+        with Session(self.engine) as session:
+            session.exec(
+                update(Job)
+                .where(Job.id == job)
+                .values(total_files=Job.total_files + total_files)
+            )
+            session.commit()
+        # This is a race condition but I think it's a "safe" one - it may return
+        # a bit higher value than the result of this update. To be fixed?
+        return self.get_job(job).total_files
 
     def register_active_agent(
         self,
@@ -336,7 +380,6 @@ class Database:
                 entry = ConfigEntry(plugin=plugin_name, key=key)
             entry.value = value
             session.add(entry)
-            session.commit()
 
     def cache_get(self, key: str, expire: int) -> Optional[str]:
         value = self.redis.get(f"cached:{key}")

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -1,0 +1,25 @@
+from sqlmodel import SQLModel, Field, ARRAY, String, Column
+from typing import Optional, List, Union
+
+
+class Job(SQLModel, table=True):
+    internal_id: Union[int, None] = Field(default=None, primary_key=True)
+    id: Union[str, None]
+    status: str
+    error: Optional[str]
+    rule_name: str
+    rule_author: str
+    raw_yara: str
+    submitted: int
+    finished: Optional[int]
+    files_limit: int
+    reference: str
+    files_processed: int
+    files_matched: int
+    files_in_progress: int
+    total_files: int
+    files_errored: int
+    taints: List[str] = Field(sa_column=Column(ARRAY(String)))
+    datasets_left: int
+    total_datasets: int
+    agents_left: int


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [n/a] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Job objects are kept in redis

**What is the new behaviour?**
Job objects are kept in postgres.

I'm consciously trying to keep everything very self-contained and don't want to change a single line outside of the Database abstraction. It's very useful to have this layer when turning around the whole storage layer. 

Related to #74 