### PR TITLE
Move the match objects to postgres

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -39,15 +39,12 @@ Possible job statuses are:
 * "cancelled" - Job was cancelled by the user or failed
 * "removed" - Job is hidden in the UI (TODO: remove this status in the future)
 
-### Meta objects (`meta:*`)
+### Match table (`match`)
 
-Meta object is a List represented by db.MatchInfo class.
+Matches represent files matched to a job.
 
-It's a list of JSONs that reprent matches for a given job. Every list element
-represents a single yara match (along with optional attributes from plugins).
-
-Each job has exactly one related meta object. For example, job with key
-`job:123456123456` will have corresponding meta object at `meta:123456123456`.
+Every match represents a single yara rule match (along with optional attributes
+from plugins).
 
 ### Agentjob objects (`agentjob:*`)
 

--- a/src/db.py
+++ b/src/db.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from typing import List, Optional, Dict, Any
 from time import time
-import json
 import random
 import string
 from redis import StrictRedis

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -2,7 +2,7 @@ from sqlmodel import SQLModel, Field, ARRAY, String, Column, Relationship
 from typing import Optional, List, Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..models.match import Match
+    from ..models.match import Match  # noqa TODO(bump flake8)
 
 
 class JobBase(SQLModel):

--- a/src/models/job.py
+++ b/src/models/job.py
@@ -1,5 +1,8 @@
-from sqlmodel import SQLModel, Field, ARRAY, String, Column
-from typing import Optional, List, Union
+from sqlmodel import SQLModel, Field, ARRAY, String, Column, Relationship
+from typing import Optional, List, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..models.match import Match
 
 
 class JobBase(SQLModel):
@@ -30,6 +33,8 @@ class Job(JobBase, table=True):
     """Job object in the database. Internal ID is an implementation detail"""
 
     internal_id: Union[int, None] = Field(default=None, primary_key=True)
+
+    matches: List["Match"] = Relationship(back_populates="job")
 
 
 class JobView(JobBase):

--- a/src/models/match.py
+++ b/src/models/match.py
@@ -1,0 +1,19 @@
+from sqlmodel import SQLModel, Field, ARRAY, String, Column, JSON, Relationship
+from typing import Optional, List, Union, Dict, Any
+
+from ..models.job import Job
+
+
+class Match(SQLModel, table=True):
+    """Represents a file matched to a job, along with a related metadata."""
+
+    id: Union[int, None] = Field(default=None, primary_key=True)
+    job_id: int = Field(foreign_key="job.internal_id")
+    # A file path on one of the daemons
+    file: str
+    # A metadata dictionary - contains various tags added by plugins
+    meta: Dict[str, Any] = Field(sa_column=Column(JSON))
+    # A list of yara rules matched to this file
+    matches: List[str] = Field(sa_column=Column(ARRAY(String)))
+
+    job: Job = Relationship(back_populates="matches")

--- a/src/models/match.py
+++ b/src/models/match.py
@@ -1,5 +1,5 @@
 from sqlmodel import SQLModel, Field, ARRAY, String, Column, JSON, Relationship
-from typing import Optional, List, Union, Dict, Any
+from typing import List, Union, Dict, Any
 
 from ..models.job import Job
 

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -5,11 +5,12 @@ from redis import Redis
 from contextlib import contextmanager
 import yara  # type: ignore
 
-from .db import Database, JobId, MatchInfo
+from .db import Database, JobId
 from .util import make_sha256_tag
 from .config import app_config
 from .plugins import PluginManager
 from .models.job import Job
+from .models.match import Match
 from .lib.yaraparse import parse_yara, combine_rules
 from .lib.ursadb import Json, UrsaDb
 from .metadata import Metadata
@@ -82,7 +83,7 @@ class Agent:
         del metadata["path"]
 
         # Update the database.
-        match = MatchInfo(orig_name, metadata, matches)
+        match = Match(file=orig_name, meta=metadata, matches=matches)
         self.db.add_match(job, match)
 
     def execute_yara(self, job: Job, files: List[str]) -> None:


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Match objects are stored in redis

**What is the new behaviour?**
Match objects are stored in postgres

A lot of this code is still suboptimal boilerplate (for example, instead of:

1. get a job from the db
2. add a match

We are doing:

1. get a job from the db
2. extract a job ID from that job and throw away the rest
3. get a job with that ID from the database (!)
4. add a match to that job

Yes, this is clearly wasteful and a relict from redis time.

This will be fixed in the refactors following complete migration to postgres (we are nearly there).


related to #74 