### PR TITLE
Bump python in pyrightconfig

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -2,7 +2,7 @@
   "include": [
     "src"
   ],
-  "pythonVersion": "3.6",
+  "pythonVersion": "3.10",
   "pythonPlatform": "Linux",
   "executionEnvironments": [{
       "root": "src"


### PR DESCRIPTION
This file is not used by anyone except me, but I'm the sole developer so it evens out.

Maybe it can even be removed now, but for now let's just bump python to the real version.