### PR TITLE
Fix deamon initialisation for tests

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -107,8 +107,6 @@ jobs:
         run: docker build -t mquery_tests:latest -f src/e2etests/Dockerfile .
       - name: run docker compose
         run: docker-compose up --scale daemon=1 --build -d
-      - name: init db
-        run: docker-compose exec -T daemon python3 -m mquery.db
       - name: run e2e tests
         run: docker run --net mquery_default -v $(readlink -f ./samples):/mnt/samples mquery_tests
       - name: get run logs

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -5,6 +5,7 @@ import logging
 from redis import Redis
 from rq import Connection, Worker  # type: ignore
 
+from .db import init_db
 from .util import setup_logging
 from . import tasks
 from .config import app_config
@@ -41,6 +42,9 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    # Initialize db - temporary measure, migrations are currently not implemented.
+    init_db()
 
     # Initial registration of the worker group.
     # The goal is to make the web UI aware of this worker and its configuration.


### PR DESCRIPTION
This is a third attempt at fixing the e2e tests. This time just make daemon init the db if it's not already updated.