### PR TITLE
Remove the metadata hashing feature

### DIFF
--- a/docs/redis.md
+++ b/docs/redis.md
@@ -63,13 +63,6 @@ When scheduling jobs, mquery needs to know how many agent groups are
 waiting for tasks. In most cases there is only one, but in distributed environment
 there may be more.
 
-### Cache objects (`cache:*`)
-
-Cache objects are arbitrary strings.
-
-Right now they are only optionally used by metadata plugins, to
-cache expensive computation in redis.
-
 ### Configuration table (`configentry`)
 
 Represented by models.configentry.ConfigEntry class.

--- a/src/db.py
+++ b/src/db.py
@@ -366,15 +366,6 @@ class Database:
             session.add(entry)
             session.commit()
 
-    def cache_get(self, key: str, expire: int) -> Optional[str]:
-        value = self.redis.get(f"cached:{key}")
-        if value is not None:
-            self.redis.expire(f"cached:{key}", expire)
-        return value
-
-    def cache_store(self, key: str, value: str, expire: int) -> None:
-        self.redis.setex(f"cached:{key}", expire, value)
-
 
 def init_db() -> None:
     engine = create_engine(app_config.database.url, echo=True)

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -1,4 +1,3 @@
-import json
 from abc import ABC
 from typing import Any, Dict, Optional
 


### PR DESCRIPTION
Currently this feature is neither useful nor used by too many of (our) plugins. And it is another use of Redis (maybe the use that makes sense, since redis was made for caching, but still).

So I think it's a good idea to remove it.