### PR TITLE
Fix Default Types in s3Index

### DIFF
--- a/src/utils/s3index.py
+++ b/src/utils/s3index.py
@@ -98,10 +98,10 @@ def main() -> None:
 
     args = parser.parse_args()
     types = list(set(args.types))
-    
+
     if not args.types:
         types = ["gram3", "text4", "wide8", "hash4"]
-        
+
     if args.workdir is None:
         logging.error("--workdir is a required parameter")
         return

--- a/src/utils/s3index.py
+++ b/src/utils/s3index.py
@@ -100,7 +100,7 @@ def main() -> None:
     types = list(set(args.types))
     
     if not args.types:
-            types = ["gram3", "text4", "wide8", "hash4"]
+        types = ["gram3", "text4", "wide8", "hash4"]
         
     if args.workdir is None:
         logging.error("--workdir is a required parameter")

--- a/src/utils/s3index.py
+++ b/src/utils/s3index.py
@@ -77,7 +77,7 @@ def main() -> None:
     parser.add_argument(
         "--type",
         dest="types",
-        help="Index types. By default [gram3, text4, wide8, hash4]",
+        help="Index types. At least one type is required.",
         action="append",
         default=[],
         choices=["gram3", "text4", "hash4", "wide8"],
@@ -100,7 +100,9 @@ def main() -> None:
     types = list(set(args.types))
 
     if not args.types:
-        raise RuntimeError("You must pick at least one index type (see --type)")
+        raise RuntimeError(
+            "You must pick at least one index type (see --type)"
+        )
 
     if args.workdir is None:
         logging.error("--workdir is a required parameter")

--- a/src/utils/s3index.py
+++ b/src/utils/s3index.py
@@ -98,7 +98,10 @@ def main() -> None:
 
     args = parser.parse_args()
     types = list(set(args.types))
-
+    
+    if not args.types:
+            types = ["gram3", "text4", "wide8", "hash4"]
+        
     if args.workdir is None:
         logging.error("--workdir is a required parameter")
         return

--- a/src/utils/s3index.py
+++ b/src/utils/s3index.py
@@ -100,7 +100,7 @@ def main() -> None:
     types = list(set(args.types))
 
     if not args.types:
-        types = ["gram3", "text4", "wide8", "hash4"]
+        raise RuntimeError("You must pick at least one index type (see --type)")
 
     if args.workdir is None:
         logging.error("--workdir is a required parameter")


### PR DESCRIPTION
**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
The default is not set when no types are given

**What is the new behaviour?**
Sets the default

**Test plan**
--> Run s3index with no --types. If it Indexes with all the types its good.
--> Run with --types and make sure its not getting overwritten.

**Closing issues**
- 
