### PR TITLE
Fix bug when there are unnecessary brackets in yara rule strings

### DIFF
--- a/src/lib/yaraparse.py
+++ b/src/lib/yaraparse.py
@@ -126,10 +126,52 @@ class YaraRuleData:
     def is_private(self) -> bool:
         return self.rule.is_private
 
+def remove_unnecessary_brackets(hex_str: str) -> str:    
+    # Function to check if brackets are necessary
+    def is_bracket_necessary(content: str) -> bool:
+        return '|' in content
+
+    # Process the string
+    result = []
+    bracket_content = ""
+    in_bracket = False
+    
+    for char in hex_str:
+        if char == '(':
+            if in_bracket:
+                bracket_content += char
+            else:
+                in_bracket = True
+        elif char == ')':
+            if in_bracket:
+                if is_bracket_necessary(bracket_content):
+                    result.append(f"({bracket_content})")
+                else:
+                    result.append(bracket_content)
+                bracket_content = ""
+                in_bracket = False
+            else:
+                result.append(char)
+        else:
+            if in_bracket:
+                bracket_content += char
+            else:
+                result.append(char)
+    
+    # Handle any remaining bracket content
+    if bracket_content:
+        if is_bracket_necessary(bracket_content):
+            result.append(f"({bracket_content})")
+        else:
+            result.append(bracket_content)
+    
+    return ''.join(result)
 
 def ursify_hex(hex_str: str) -> UrsaExpression:
     # easier to manage
     hex_str = hex_str.replace(" ", "")
+
+    hex_str = remove_unnecessary_brackets(hex_str)
 
     # alternatives, are nested alternatives a thing?
     hex_parts = re.split(r"\(.*?\)", hex_str)


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [-] I've added automated tests for my change (if applicable, optional)
- [-] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
try yara rule:
```
rule parse_exception_example {
    strings:
        $xor_key_size   = { ((BB)|(68))??020000} 
        $c2         = { FF FF 68 74 74 70 }
    condition:
        all of them
}
```
Mquery can't parse it

**What is the new behaviour?**
The new additional function deletes unnecessary brackets and parser works well

**Test plan**
Just send a query with the following yara rule:
```
rule parse_exception_example {
    strings:
        $xor_key_size   = { ((BB)|(68))??020000} 
        $c2         = { FF FF 68 74 74 70 }
    condition:
        all of them
}
```