### PR TITLE
fix: change general package install manager to yarn

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           node-version: '12.x'
       - name: install dependencies
-        run: npm install
+        run: yarn install
       - name: build
         run: npm build
   test_unit:

--- a/deploy/docker/dev.frontend.Dockerfile
+++ b/deploy/docker/dev.frontend.Dockerfile
@@ -3,5 +3,5 @@ FROM node:18 AS build
 RUN npm install -g serve
 COPY src/mqueryfront /app
 WORKDIR /app
-RUN npm install --legacy-peer-deps
+RUN yarn install --legacy-peer-deps
 CMD ["npm", "start"]

--- a/deploy/docker/web.Dockerfile
+++ b/deploy/docker/web.Dockerfile
@@ -3,7 +3,7 @@ FROM node:18 AS build
 RUN npm install -g serve
 COPY src/mqueryfront /app
 WORKDIR /app
-RUN npm install --legacy-peer-deps && npm run build
+RUN yarn install --legacy-peer-deps && npm run build
 
 FROM python:3.10
 

--- a/docs/how-to/install-native.md
+++ b/docs/how-to/install-native.md
@@ -46,7 +46,7 @@ we can start a web server.
 
 ```shell
 cd /opt/mquery/src/mqueryfront
-npm install --legacy-peer-deps
+yarn install --legacy-peer-deps
 npm run build
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [x] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Currently ```yarn.lock``` is responsible for managing exact dependency tree, yet ```npm``` is used for general package installation via ```npm install```

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
```npm install``` has been changed to ```yarn install```, so now ```yarn.lock``` has sense in this project.

**Test plan**
<!-- Explain how to test your changes -->
Change should be seamless, nothing should change in regards to mquery's functionality.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

n.a.
