### PR TITLE
fix: styling of rulenames badges wraps properly

### DIFF
--- a/src/mqueryfront/src/query/QueryMatchesItem.js
+++ b/src/mqueryfront/src/query/QueryMatchesItem.js
@@ -19,15 +19,19 @@ const QueryMatchesItem = (props) => {
             </a>
         ));
 
-    const matchBadges = Object.values(matches).map((v) => (
-        <span
-            key={v}
-            className="badge rounded-pill bg-primary ms-1 mt-1 cursor-pointer"
-            onClick={() => props.changeFilter(v)}
-        >
-            {v}
-        </span>
-    ));
+    const matchBadges = (
+        <div>
+            {Object.values(matches).map((v) => (
+                <span
+                    key={v}
+                    className="badge rounded-pill bg-primary ms-1 mt-1 cursor-pointer text-wrap"
+                    onClick={() => props.changeFilter(v)}
+                >
+                    {v}
+                </span>
+            ))}
+        </div>
+    );
 
     return (
         <tr>


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
Currently badges in query result page go out of page when given too long names, as per https://user-images.githubusercontent.com/20182642/82444130-6a327c00-9aab-11ea-8693-63cf5dcb0cce.gif https://github.com/CERT-Polska/mquery/issues/196

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Now badges wrap properly to new line with additional text linebreaks.

**Test plan**
<!-- Explain how to test your changes -->
Try to search for a query with multiple rule names, some of them very long and try to match many files to see if multiple result search also works properly. Try resizing the window, zooming in and out and try to find unexpected/unwished for behavior.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #196
