### PR TITLE
Initialize the database automatically when starting mquery #402

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,6 @@ mkdir samples
 # expect files in ./samples directory, and keep index in ./index.
 vim .env
 docker compose up --scale daemon=3  # this will take a while
-docker compose exec web python3 -m mquery.db
 ```
 
 - Good for testing mquery and production deployments on a single server
@@ -38,7 +37,6 @@ cd mquery
 # expect files in ./samples directory, and keep index in ./index.
 vim .env
 docker compose -f docker-compose.dev.yml up  # this will take a while
-docker compose exec dev-web python3 -m mquery.db
 ```
 
 - Good for development - all file changes will be picked up automatically.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft src/mqueryfront/dist
+include src/alembic.ini

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ git clone https://github.com/CERT-Polska/mquery.git
 cd mquery
 vim .env  # optional - change samples and index directory locations
 docker compose up --scale daemon=3  # building the images will take a while
-docker compose exec web python3 -m mquery.db
 ```
 
 The web interface should be available at `http://localhost`.

--- a/docs/how-to/install-native.md
+++ b/docs/how-to/install-native.md
@@ -118,7 +118,6 @@ Now you need to create and configure a database
 ```shell
 psql -c "CREATE DATABASE mquery"
 source /opt/mquery/venv/bin/activate  # remember, we need virtualenv
-python3 -m mquery.db  # initialize the mquery database
 ```
 
 ### Start everything

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(
         "mquery.lib",
         "mquery.plugins",
         "mquery.models",
+        "mquery.migrations",
+        "mquery.migrations.versions",
     ],
     package_dir={"mquery": "src"},
     include_package_data=True,

--- a/src/alembic.ini
+++ b/src/alembic.ini
@@ -1,5 +1,5 @@
 [alembic]
-script_location = migrations
+script_location = %(here)s/migrations
 prepend_sys_path = .
 version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 

--- a/src/app.py
+++ b/src/app.py
@@ -24,13 +24,7 @@ from cryptography.hazmat.primitives import serialization
 
 from .config import app_config
 from .util import mquery_version
-from .db import (
-    Database,
-    is_alembic_version_present,
-    is_database_initilized,
-    run_alembic_legacy_stamp,
-    run_alembic_upgrade,
-)
+from .db import Database
 from .lib.yaraparse import parse_yara
 from .plugins import PluginManager
 from .lib.ursadb import UrsaDb
@@ -54,21 +48,7 @@ from .schema import (
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Check if the database is initilized
-    if is_database_initilized():
-        # Check if database contains alembic_version table
-        if is_alembic_version_present():
-            # If True it means that we can run alembic upgrade head without worry.
-            pass
-        # If False database is not up-to-date
-        # but we can't just run alembic head upgrade as there is no alembic_version table
-        # so we need to run alemibc stamp dbb81bd4d47f
-        # as dbb81bd4d47f is the number of last migration before alembic head upgrade was added
-        else:
-            run_alembic_legacy_stamp()
-
-    # finally we can run alembic upgrade head to upgrade (if needed) the database
-    run_alembic_upgrade()
+    db.alembic_upgrade()
     yield
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [ ] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ ] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Currently we needed to initilize database by hand: `python3 -m mquery.db`.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Now the database initialization is automatic and it uses `alembic upgrade head` instad of `mquery.db` so it also applies migrations. Also if the database already exists it will stamp it and create `alembic_version` for future migrations to be applied via `upgrade head`

**Test plan**
<!-- Explain how to test your changes -->
For new instance:  Create new instance and it will initilize database automatically.
For existing database: Remove (unnecessary for dev containers)  web container and set it up again.
Then you can check if there is `alembic_version` in postgresql.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #402 
