### PR TITLE
fix: queryFieldPane doesn't dissapear after returning from results page

### DIFF
--- a/src/mqueryfront/src/query/QueryLayoutManager.js
+++ b/src/mqueryfront/src/query/QueryLayoutManager.js
@@ -60,23 +60,24 @@ const QueryLayoutManager = (props) => {
         queryResults
     ) : null;
 
-    const queryFieldPane = qhash && isCollapsed ? null : (
-        <div className={resultsTab ? "col-md-6" : "col-md-12"}>
-            <QueryField
-                readOnly={!!qhash}
-                onSubmitQuery={onSubmitQuery}
-                onEditQuery={onEditQuery}
-                onParseQuery={onParseQuery}
-                onTaintSelect={onTaintSelect}
-                availableTaints={availableTaints}
-                rawYara={rawYara}
-                onYaraUpdate={onYaraUpdate}
-                parsedError={parsedError}
-                selectedTaints={selectedTaints}
-                forceSlowQueries={forceSlowQueries}
-            />
-        </div>
-    );
+    const queryFieldPane =
+        qhash && isCollapsed ? null : (
+            <div className={resultsTab ? "col-md-6" : "col-md-12"}>
+                <QueryField
+                    readOnly={!!qhash}
+                    onSubmitQuery={onSubmitQuery}
+                    onEditQuery={onEditQuery}
+                    onParseQuery={onParseQuery}
+                    onTaintSelect={onTaintSelect}
+                    availableTaints={availableTaints}
+                    rawYara={rawYara}
+                    onYaraUpdate={onYaraUpdate}
+                    parsedError={parsedError}
+                    selectedTaints={selectedTaints}
+                    forceSlowQueries={forceSlowQueries}
+                />
+            </div>
+        );
 
     return (
         <div className="container-fluid">

--- a/src/mqueryfront/src/query/QueryLayoutManager.js
+++ b/src/mqueryfront/src/query/QueryLayoutManager.js
@@ -60,7 +60,7 @@ const QueryLayoutManager = (props) => {
         queryResults
     ) : null;
 
-    const queryFieldPane = isCollapsed ? null : (
+    const queryFieldPane = qhash && isCollapsed ? null : (
         <div className={resultsTab ? "col-md-6" : "col-md-12"}>
             <QueryField
                 readOnly={!!qhash}


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
<!-- Explain how the code works currently -->
Currently whenever going back to query page from itself via navigation the page becomes blank.

**What is the new behaviour?**
<!-- Explain how the code works after your changes -->
Bug has been successfully fixed and now going back via CERT.pl logo / Query button / browser back button to query page, it is rendered correctly with it's last inputs.

**Test plan**
<!-- Explain how to test your changes -->
Click through the page and check if everything is still rendering properly.

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #413
