### PR TITLE
Make fields nullable again

### DIFF
--- a/src/models/jobagent.py
+++ b/src/models/jobagent.py
@@ -1,5 +1,5 @@
-from sqlalchemy import Column, ForeignKey
-from sqlmodel import SQLModel, Field, Relationship
+from sqlalchemy import ForeignKey
+from sqlmodel import SQLModel, Field, Relationship, Column
 from typing import Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -14,7 +14,9 @@ class JobAgent(SQLModel, table=True):
     task_in_progress: int
 
     job_id: int = Field(
-        sa_column=Column(ForeignKey("job.internal_id", ondelete="CASCADE"))
+        sa_column=Column(
+            ForeignKey("job.internal_id", ondelete="CASCADE"), nullable=False
+        ),
     )
     job: "Job" = Relationship(back_populates="agents")
 

--- a/src/models/match.py
+++ b/src/models/match.py
@@ -17,6 +17,8 @@ class Match(SQLModel, table=True):
     matches: List[str] = Field(sa_column=Column(ARRAY(String)))
 
     job_id: int = Field(
-        sa_column=Column(ForeignKey("job.internal_id", ondelete="CASCADE"))
+        sa_column=Column(
+            ForeignKey("job.internal_id", ondelete="CASCADE"), nullable=False
+        )
     )
     job: Job = Relationship(back_populates="matches")


### PR DESCRIPTION
After #412 the database status is not equivalent to schema in the code, and migrations want to change job_id fields to nullable. In that PR they were changed from a simple Field() to a Field(sa_column=...) which triggered this change.

This means that now trying to create a new migration will add two unrelated changes (job_id for jobagent and match).

This PR bumps sqlmodel and makes them non-nullable again.
