### PR TITLE
257 user model refactor the config handling

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -182,12 +182,7 @@ def get_user_roles(user: User) -> List[UserRole]:
     client_id = db.config.openid_client_id
     user_roles = user.roles(client_id)
     auth_default_roles = db.config.auth_default_roles
-    if not auth_default_roles:
-        auth_default_roles = "admin"
-    default_roles = [
-        UserRole[role.strip()] for role in auth_default_roles.split(",")
-    ]
-    all_roles = set(user_roles + default_roles)
+    all_roles = set(user_roles + auth_default_roles)
     return sum((expand_role(role) for role in all_roles), [])
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -114,7 +114,7 @@ class User:
 
 
 async def current_user(authorization: Optional[str] = Header(None)) -> User:
-    auth_enabled = db.get_mquery_config_key("auth_enabled")
+    auth_enabled = db.config.auth_enabled
     if not auth_enabled or auth_enabled == "false":
         return User(None)
 
@@ -134,7 +134,7 @@ async def current_user(authorization: Optional[str] = Header(None)) -> User:
 
     _bearer, token = token_parts
 
-    secret = db.get_mquery_config_key("openid_secret")
+    secret = db.config.openid_secret
     if secret is None:
         raise RuntimeError("Invalid configuration - missing_openid_secret.")
 
@@ -169,7 +169,7 @@ class RoleChecker:
         self.need_permissions = need_permissions
 
     def __call__(self, user: User = Depends(current_user)):
-        auth_enabled = db.get_mquery_config_key("auth_enabled")
+        auth_enabled = db.config.auth_enabled
         if not auth_enabled or auth_enabled == "false":
             return
 
@@ -198,9 +198,9 @@ can_download_files = RoleChecker([UserRole.can_download_files])
 def get_user_roles(user: User) -> List[UserRole]:
     """Get all roles assigned to user, taking into account the
     system configuration (like default configured roles)"""
-    client_id = db.get_mquery_config_key("openid_client_id")
+    client_id = db.config.openid_client_id
     user_roles = user.roles(client_id)
-    auth_default_roles = db.get_mquery_config_key("auth_default_roles")
+    auth_default_roles = db.config.auth_default_roles
     if not auth_default_roles:
         auth_default_roles = "admin"
     default_roles = [
@@ -455,7 +455,7 @@ def query(
         ]
 
     degenerate_rules = [r.name for r in rules if r.parse().is_degenerate]
-    allow_slow = db.get_mquery_config_key("query_allow_slow") == "true"
+    allow_slow = db.config.query_allow_slow == "true"
     if degenerate_rules and not (allow_slow and data.force_slow_queries):
         if allow_slow:
             # Warning: "You can force a slow query" literal is used to
@@ -601,9 +601,9 @@ def query_remove(
 def server() -> ServerSchema:
     return ServerSchema(
         version=mquery_version(),
-        auth_enabled=db.get_mquery_config_key("auth_enabled"),
-        openid_url=db.get_mquery_config_key("openid_url"),
-        openid_client_id=db.get_mquery_config_key("openid_client_id"),
+        auth_enabled=db.config.auth_enabled,
+        openid_url=db.config.openid_url,
+        openid_client_id=db.config.openid_client_id,
         about=app_config.mquery.about,
     )
 

--- a/src/app.py
+++ b/src/app.py
@@ -577,7 +577,7 @@ def query_remove(
 def server() -> ServerSchema:
     return ServerSchema(
         version=mquery_version(),
-        auth_enabled=db.config.auth_enabled,
+        auth_enabled=str(db.config.auth_enabled).lower(),
         openid_url=db.config.openid_url,
         openid_client_id=db.config.openid_client_id,
         about=app_config.mquery.about,

--- a/src/db.py
+++ b/src/db.py
@@ -72,9 +72,10 @@ class UserModelConfig:
             "auth_default_roles"
         )
         if auth_default_roles is None:
-            return []
-        else:
-            return [role.strip() for role in auth_default_roles.split(",")]
+            auth_default_roles = "admin"
+        return [
+            UserRole[role.strip()] for role in auth_default_roles.split(",")
+        ]
 
     @property
     def openid_client_id(self) -> str:

--- a/src/db.py
+++ b/src/db.py
@@ -44,6 +44,22 @@ class TaskType(Enum):
 JobId = str
 
 
+class UserModelConfig:
+    def __init__(self, db_instance):
+        self.db = db_instance
+
+    def __getattr__(self, role_name):
+        # auth_default_roles = self.db.get_mquery_config_key(role_name)
+        # if auth_default_roles is None:
+        #     return []
+        # else:
+        #     print(role.strip() for role in auth_default_roles.split(","))
+        #     return [
+        #         role.strip() for role in auth_default_roles.split(",")
+        #     ]
+        return self.db.get_mquery_config_key(role_name)
+
+
 class Database:
     def __init__(self, redis_host: str, redis_port: int) -> None:
         self.redis: Any = StrictRedis(
@@ -56,6 +72,10 @@ class Database:
         Queue(agent, connection=self.redis).enqueue(
             task, *args, job_timeout=app_config.rq.job_timeout
         )
+
+    @property
+    def config(self):
+        return UserModelConfig(self)
 
     @contextmanager
     def session(self):

--- a/src/db.py
+++ b/src/db.py
@@ -78,7 +78,7 @@ class UserModelConfig:
         ]
 
     @property
-    def openid_client_id(self) -> str:
+    def openid_client_id(self) -> str | None:
         return self.db.get_mquery_config_key("openid_client_id")
 
     @property
@@ -87,13 +87,10 @@ class UserModelConfig:
 
     @property
     def auth_enabled(self) -> bool:
-        auth_enabled = self.db.get_mquery_config_key("auth_enabled")
-        if not auth_enabled or auth_enabled == "false":
-            return False
-        return True
+        return self.db.get_mquery_config_key("auth_enabled") == "true"
 
     @property
-    def openid_url(self) -> str:
+    def openid_url(self) -> str | None:
         return self.db.get_mquery_config_key("openid_url")
 
     @property

--- a/src/schema.py
+++ b/src/schema.py
@@ -101,7 +101,7 @@ class BackendStatusDatasetsSchema(BaseModel):
 
 class ServerSchema(BaseModel):
     version: str
-    auth_enabled: Optional[bool]
+    auth_enabled: Optional[str]
     openid_url: Optional[str]
     openid_client_id: Optional[str]
     about: str

--- a/src/schema.py
+++ b/src/schema.py
@@ -101,7 +101,7 @@ class BackendStatusDatasetsSchema(BaseModel):
 
 class ServerSchema(BaseModel):
     version: str
-    auth_enabled: Optional[str]
+    auth_enabled: Optional[bool]
     openid_url: Optional[str]
     openid_client_id: Optional[str]
     about: str


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [x] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [x] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
db.get_mquery_config_key("default_role) when called returns different types

**What is the new behaviour?**
I created UserModelConfig with properties  like auth_default_roles, openid_client_id, query_allow_slow etc. and now i call db.config.default_role

**Test plan**
<!-- Explain how to test your changes -->

<!-- After submitting, your code will be tested by the CI pipeline. Please
ensure that all tests pass. If they don't at first, please update your code -->

**Closing issues**

<!-- Add in issue numbers related to this PR, if applicable -->

fixes #257 
