### PR TITLE
Add an optional link between mquery results and mwdb

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -580,6 +580,7 @@ def server() -> ServerSchema:
         auth_enabled=str(db.config.auth_enabled).lower(),
         openid_url=db.config.openid_url,
         openid_client_id=db.config.openid_client_id,
+        mwdb_url=db.config.mwdb_url,
         about=app_config.mquery.about,
     )
 

--- a/src/db.py
+++ b/src/db.py
@@ -97,6 +97,9 @@ class UserModelConfig:
     def openid_secret(self) -> str | None:
         return self.db.get_mquery_config_key("openid_secret")
 
+    @property
+    def mwdb_url(self) -> str | None:
+        return self.db.get_mquery_config_key("mwdb_url")
 
 class Database:
     def __init__(self, redis_host: str, redis_port: int) -> None:
@@ -404,6 +407,8 @@ class Database:
             "openid_secret": "Secret used for JWT token verification",
             # Query and performance config
             "query_allow_slow": "Allow users to run queries that will end up scanning the whole malware collection",
+            # Link with Mwdb
+            "mwdb_url": "MalwareDB base url",
         }
 
     def get_config(self) -> List[ConfigSchema]:

--- a/src/mqueryfront/src/App.js
+++ b/src/mqueryfront/src/App.js
@@ -19,6 +19,8 @@ function getCurrentTokenOrNull() {
     }
 }
 
+export const AppContext = React.createContext(null);
+
 function App() {
     const [config, setConfig] = useState(null);
 
@@ -52,24 +54,26 @@ function App() {
 
     return (
         <div className="App">
-            <Navigation session={token} config={config} logout={logout} />
-            <Routes>
-                <Route exact path="/" element={<QueryPage />} />
-                <Route path="/query/:hash" element={<QueryPage />} />
-                <Route exact path="/recent" element={<RecentPage />} />
-                <Route exact path="/config" element={<ConfigPage />} />
-                <Route exact path="/status" element={<StatusPage />} />
-                <Route
-                    exact
-                    path="/about"
-                    element={<AboutPage config={config} />}
-                />
-                <Route
-                    exact
-                    path="/auth"
-                    element={<AuthPage config={config} login={login} />}
-                />
-            </Routes>
+            <AppContext.Provider value={{ config: config }}>
+                <Navigation session={token} config={config} logout={logout} />
+                <Routes>
+                    <Route exact path="/" element={<QueryPage />} />
+                    <Route path="/query/:hash" element={<QueryPage />} />
+                    <Route exact path="/recent" element={<RecentPage />} />
+                    <Route exact path="/config" element={<ConfigPage />} />
+                    <Route exact path="/status" element={<StatusPage />} />
+                    <Route
+                        exact
+                        path="/about"
+                        element={<AboutPage config={config} />}
+                    />
+                    <Route
+                        exact
+                        path="/auth"
+                        element={<AuthPage config={config} login={login} />}
+                    />
+                </Routes>
+            </AppContext.Provider>
         </div>
     );
 }

--- a/src/mqueryfront/src/components/ActionMatchDisplay.js
+++ b/src/mqueryfront/src/components/ActionMatchDisplay.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+const ActionMatchDisplay = (props) => {
+    const { text, href } = props;
+
+    return href ?
+        (
+            <a
+                href={href}
+                target="_blank"
+            >
+                {text}
+            </a>
+        )
+        : text;
+};
+
+
+export default ActionMatchDisplay;

--- a/src/mqueryfront/src/config/ConfigEntries.js
+++ b/src/mqueryfront/src/config/ConfigEntries.js
@@ -11,6 +11,7 @@ const KNOWN_RULES = {
     auth_enabled: R_BOOL,
     auth_default_roles: R_ROLES,
     query_allow_slow: R_BOOL,
+    mwdb_url: R_URL,
 };
 
 class ConfigRow extends Component {

--- a/src/mqueryfront/src/query/QueryMatches.js
+++ b/src/mqueryfront/src/query/QueryMatches.js
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import Pagination from "replace-js-pagination";
 import FilterIcon from "../components/FilterIcon";
 import QueryMatchesItem from "./QueryMatchesItem";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import api, { api_url } from "../api";
+import { AppContext } from "../App";
+
 import {
     faCopy,
     faDownload,
@@ -68,6 +70,8 @@ const QueryMatches = (props) => {
 
     const [filters, setFilter] = useState([]);
 
+    const { config } = useContext(AppContext);
+
     const updateFilter = (name) => {
         if (!filters.includes(name)) {
             setFilter([...filters, name]);
@@ -88,6 +92,11 @@ const QueryMatches = (props) => {
             return null;
         })
         .map((match, index) => {
+            const display_url = config && config["mwdb_url"] ?
+                new URL(`/file/${match.meta.sha256.display_text}`, config["mwdb_url"])
+                :
+                undefined;
+
             const downloadUrl = new URL(
                 `${api_url}/download`,
                 document.baseURI
@@ -102,6 +111,7 @@ const QueryMatches = (props) => {
                 <QueryMatchesItem
                     key={match.file}
                     match={match}
+                    display_url={display_url}
                     download_url={downloadUrl.href}
                     filters={filters}
                     setFilter={setFilter}

--- a/src/mqueryfront/src/query/QueryMatchesItem.js
+++ b/src/mqueryfront/src/query/QueryMatchesItem.js
@@ -1,10 +1,11 @@
 import React from "react";
 import path from "path-browserify";
 import ActionDownload from "../components/ActionDownload";
+import ActionMatchDisplay from "../components/ActionMatchDisplay";
 import ActionCopyToClipboard from "../components/ActionCopyToClipboard";
 
 const QueryMatchesItem = (props) => {
-    const { match, download_url } = props;
+    const { match, download_url, display_url } = props;
     const { matches, meta, file } = match;
 
     const fileBasename = path.basename(file);
@@ -38,7 +39,7 @@ const QueryMatchesItem = (props) => {
             <td>
                 <div className="d-flex">
                     <div className="text-truncate" style={{ minWidth: 50 }}>
-                        {meta.sha256.display_text}
+                        <ActionMatchDisplay text={meta.sha256.display_text} href={display_url} />
                     </div>
                     <small className="text-secondary">
                         <div className="btn-group " role="group">

--- a/src/schema.py
+++ b/src/schema.py
@@ -104,4 +104,5 @@ class ServerSchema(BaseModel):
     auth_enabled: Optional[str]
     openid_url: Optional[str]
     openid_client_id: Optional[str]
+    mwdb_url: Optional[str]
     about: str


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- Please fill this template before submitting your PR (fill the boxes using "x") -->

**Your checklist for this pull request**
- [X ] I've read the [contributing guideline](https://github.com/CERT-Polska/mquery/blob/master/CONTRIBUTING.md).
- [ X] I've tested my changes by building and running mquery, and testing changed functionality (if applicable)
- [ ] I've added automated tests for my change (if applicable, optional)
- [ ] I've updated documentation to reflect my change (if applicable)

**What is the current behaviour?**
There is currently no way to switch between mquery results and mwdb 
The user has to copy the sample hash and select it in mwdb

**What is the new behaviour?**
A new option is added to the global Mquery plugin to be able to specify the mwdb instance url.
If this option is set, links are displayed in the mquery results panels. They can be used to switch to mwdb easily.
If this options is not set, the current behaviour is unchanged

**Test plan**
- Test 1

> 1. Configure the key mwdb_url of Mquery plugin  in the config panel (http://localhost:config) with the MWDB base url
> 2. Check that yara results are now displayed as links
> 3. Check that a new tab with the sample MWDB page is opened on click 

- Test 2

> 1. Remove the key mwdb_url of Mquery plugin  in the config panel (http://localhost:config) with the MWDB base url
> 2. Check that yara results are not displayed as links

